### PR TITLE
Update player status display and manage game state transitions

### DIFF
--- a/src/WaterWizard.Client/GameStateManager.cs
+++ b/src/WaterWizard.Client/GameStateManager.cs
@@ -522,7 +522,8 @@ namespace WaterWizard.Client
 
             for (int i = 0; i < players.Count; i++)
             {
-                string playerText = players[i].ToString();
+                string status = players[i].IsReady ? "(Ready)" : "(Not Ready)";
+                string playerText = $"{players[i].Name} {status}";
                 int textWidth = Raylib.MeasureText(playerText, 18);
                 if (playerListY + i * 30 < playerListY + maxListHeight)
                 {

--- a/src/WaterWizard.Client/NetworkManager.cs
+++ b/src/WaterWizard.Client/NetworkManager.cs
@@ -379,6 +379,11 @@ namespace WaterWizard.Client
                     string message = reader.GetString();
                     Console.WriteLine($"[Client] Nachricht vom Server empfangen: {message}");
 
+                    if (message == "StartGame")
+                    {
+                        GameStateManager.Instance.SetStateToInGame();
+                    }
+                    
                     if (message == "EnterLobby")
                     {
                         Console.WriteLine("[Client] Betrete die Lobby...");

--- a/src/WaterWizard.Server/WaterWizard.Server.csproj
+++ b/src/WaterWizard.Server/WaterWizard.Server.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WaterWizard.Shared\WaterWizard.Shared.csproj" />
+    <ProjectReference Include="..\WaterWizard.Client\WaterWizard.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of the WaterWizard game, including improvements to player readiness tracking, synchronization between the server and clients, and codebase refactoring for better maintainability. The most important updates include replacing the `connectedPlayers` list with a `ConnectedPlayers` dictionary on the server, implementing game start logic when all players are ready, and updating the client-side UI to display player readiness.

### Server-Side Changes:

* Replaced the `connectedPlayers` list with a `ConnectedPlayers` dictionary to track both player connections and their readiness status. This improves the server's ability to manage player states. (`src/WaterWizard.Server/Program.cs`) [[1]](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL13-R13) [[2]](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL73-R73) [[3]](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL93-R88) [[4]](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL184-R186)
* Added logic to check if all players are ready and broadcast a "StartGame" message to clients, initiating the game when readiness conditions are met. (`src/WaterWizard.Server/Program.cs`)

### Client-Side Changes:

* Updated the `DrawPreStartLobby` method to display each player's readiness status ("Ready" or "Not Ready") in the lobby UI. (`src/WaterWizard.Client/GameStateManager.cs`)
* Added handling for the "StartGame" message to transition the client to the in-game state when the server signals the start of the game. (`src/WaterWizard.Client/NetworkManager.cs`)

### Build Configuration:

* Added a project reference to the client project (`WaterWizard.Client`) in the server project file to ensure proper dependency management. (`src/WaterWizard.Server/WaterWizard.Server.csproj`)