### PR TITLE
fix: update Dockerfile to expose UDP port and remove unnecessary key …

### DIFF
--- a/src/WaterWizard.Server/Dockerfile
+++ b/src/WaterWizard.Server/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 COPY --from=build /app/publish .
 
 
-EXPOSE 7777
+EXPOSE 7777/udp
 
 
 ENTRYPOINT ["dotnet", "WaterWizard.Server.dll"]

--- a/src/WaterWizard.Server/Program.cs
+++ b/src/WaterWizard.Server/Program.cs
@@ -193,13 +193,6 @@ static class Program
 
                         while (true)
                         {
-                            if (Console.KeyAvailable)
-                            {
-                                var key = Console.ReadKey(true);
-                                if (key.Key == ConsoleKey.Escape)
-                                    break;
-                            }
-
                             server?.PollEvents();
                             Thread.Sleep(15);
                         }


### PR DESCRIPTION
This pull request includes changes to the `WaterWizard.Server` project, focusing on improving the Docker configuration and simplifying the server's main loop. Below are the most important changes:

### Docker Configuration Update:
* Modified the `Dockerfile` to expose port `7777` as a UDP port instead of the default TCP port. This change ensures the correct protocol is used for network communication. (`src/WaterWizard.Server/Dockerfile`, [src/WaterWizard.Server/DockerfileL26-R26](diffhunk://#diff-952c0582859ce7c43632e10d067b390a30e1096afd62d0c35b591b9dfce2cd5aL26-R26))

### Code Simplification:
* Removed the keyboard polling logic from the `Main` method in `Program.cs`, simplifying the server's main loop by eliminating unnecessary checks for the Escape key. (`src/WaterWizard.Server/Program.cs`, [src/WaterWizard.Server/Program.csL196-L202](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL196-L202))…check in Program.cs