### PR TITLE
fix: update docker-compose to expose UDP port for waterwizard-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       context: .
       dockerfile: ./src/WaterWizard.Server/Dockerfile
     ports:
-      - "7777:7777"
+      - "7777:7777/udp"
     environment:
       - PUBLIC_ADDRESS=${SERVER_IP}


### PR DESCRIPTION
Deployed instance runs
This pull request includes a small change to the `docker-compose.yml` file. The change specifies the protocol for the port mapping of the `services` section, updating it to use UDP instead of the default TCP.

next time i will use the right branch naming convention, but deployed server instance should work now 