### PR TITLE
F122 choose port to connect to

### DIFF
--- a/src/WaterWizard.Client/GameStateManager.cs
+++ b/src/WaterWizard.Client/GameStateManager.cs
@@ -406,8 +406,8 @@ namespace WaterWizard.Client
 
         private void DrawConnectMenu()
         {
-            Raylib.DrawText("Enter IP Address to Connect:", screenWidth / 3,
-                            screenHeight / 3, 20, Color.DarkBlue);
+            Raylib.DrawText("Enter IP Address:", screenWidth / 3,
+                            screenHeight / 2 - 40, 20, Color.DarkBlue);
 
             Rectangle inputBox =
                 new((float)screenWidth / 3, (float)screenHeight / 2, 300, 40);
@@ -419,8 +419,8 @@ namespace WaterWizard.Client
             Raylib.DrawText(inputText, (int)inputBox.X + 5, (int)inputBox.Y + 10, 20,
                             Color.Black);
 
-            Raylib.DrawText("Enter Port:", screenWidth / 3, screenHeight / 3 + 60, 20, Color.DarkBlue); 
-            Rectangle portInputBox = new Rectangle((float)screenWidth / 3, (float)screenHeight / 3 + 90, 100, 40); 
+            Raylib.DrawText("Enter Port:", screenWidth / 2 + 40, screenHeight / 2 - 40, 20, Color.DarkBlue); 
+            Rectangle portInputBox = new((float)screenWidth / 3 + 300, (float)screenHeight / 2, 100, 40); 
             Raylib.DrawRectangleRec(portInputBox, isEditingPort ? Color.White : Color.LightGray);
             Raylib.DrawRectangleLines((int)portInputBox.X, (int)portInputBox.Y, (int)portInputBox.Width, (int)portInputBox.Height, Color.DarkBlue);
             Raylib.DrawText(inputPortText, (int)portInputBox.X + 5, (int)portInputBox.Y + 10, 20, Color.Black);
@@ -450,7 +450,7 @@ namespace WaterWizard.Client
                 HandleTextInput();
             }
 
-            Rectangle connectButton = new Rectangle(
+            Rectangle connectButton = new(
                 (float)screenWidth / 2 - 80, (float)screenHeight / 2 + 60, 160, 40);
             if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(),
                                               connectButton) &&


### PR DESCRIPTION
This pull request enhances the `DrawConnectMenu` functionality in the `GameStateManager` class by adding support for specifying both IP address and port when connecting to a server. It also improves user input handling and UI layout for better usability.

### Enhancements to the connection menu:

* Added a new `inputPortText` field to store the port input and a corresponding `isEditingPort` flag to track if the port input box is active.
* Updated `DrawConnectMenu` to display separate input fields for IP address and port, with appropriate labels and layout adjustments. The port input field includes validation to ensure the entered port is within the valid range (1–65535). [[1]](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L407-R425) [[2]](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L420-R509)

### Improvements to input handling:

* Modified `HandleTextInput` to handle input for both IP address and port fields, including character validation (e.g., numeric-only for ports) and length restrictions. Added support for backspace, Enter, and Escape keys to manage input focus and clear inputs.