### PR TITLE
F122 choose port to connect to

### DIFF
--- a/src/WaterWizard.Client/GameStateManager.cs
+++ b/src/WaterWizard.Client/GameStateManager.cs
@@ -406,8 +406,8 @@ namespace WaterWizard.Client
 
         private void DrawConnectMenu()
         {
-            Raylib.DrawText("Enter IP Address to Connect:", screenWidth / 3,
-                            screenHeight / 3, 20, Color.DarkBlue);
+            Raylib.DrawText("Enter IP Address:", screenWidth / 3,
+                            screenHeight / 2 - 40, 20, Color.DarkBlue);
 
             Rectangle inputBox =
                 new((float)screenWidth / 3, (float)screenHeight / 2, 300, 40);
@@ -419,8 +419,8 @@ namespace WaterWizard.Client
             Raylib.DrawText(inputText, (int)inputBox.X + 5, (int)inputBox.Y + 10, 20,
                             Color.Black);
 
-            Raylib.DrawText("Enter Port:", screenWidth / 3, screenHeight / 3 + 60, 20, Color.DarkBlue); 
-            Rectangle portInputBox = new Rectangle((float)screenWidth / 3, (float)screenHeight / 3 + 90, 100, 40); 
+            Raylib.DrawText("Enter Port:", screenWidth / 2 + 40, screenHeight / 2 - 40, 20, Color.DarkBlue); 
+            Rectangle portInputBox = new((float)screenWidth / 3 + 300, (float)screenHeight / 2, 100, 40); 
             Raylib.DrawRectangleRec(portInputBox, isEditingPort ? Color.White : Color.LightGray);
             Raylib.DrawRectangleLines((int)portInputBox.X, (int)portInputBox.Y, (int)portInputBox.Width, (int)portInputBox.Height, Color.DarkBlue);
             Raylib.DrawText(inputPortText, (int)portInputBox.X + 5, (int)portInputBox.Y + 10, 20, Color.Black);
@@ -450,7 +450,7 @@ namespace WaterWizard.Client
                 HandleTextInput();
             }
 
-            Rectangle connectButton = new Rectangle(
+            Rectangle connectButton = new(
                 (float)screenWidth / 2 - 80, (float)screenHeight / 2 + 60, 160, 40);
             if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(),
                                               connectButton) &&

--- a/src/WaterWizard.Client/GameStateManager.cs
+++ b/src/WaterWizard.Client/GameStateManager.cs
@@ -93,7 +93,7 @@ public class GameStateManager
         GameScreen.UpdateScreenSize(width, height);
     }
 
-    /// <summary>
+        /// <summary>
     /// Aktualisiert den Spielzustand und zeichnet die entsprechende
     /// Benutzeroberfläche. Diese Methode muss in jedem Frame aufgerufen werden.
     /// </summary>
@@ -129,83 +129,6 @@ public class GameStateManager
         }
         else
         {
-            Raylib.DrawText("Enter IP Address:", screenWidth / 3,
-                            screenHeight / 2 - 40, 20, Color.DarkBlue);
-
-            Rectangle inputBox =
-                new((float)screenWidth / 3, (float)screenHeight / 2, 300, 40);
-            Raylib.DrawRectangleRec(inputBox,
-                                    isEditingIp ? Color.White : Color.LightGray);
-            Raylib.DrawRectangleLines((int)inputBox.X, (int)inputBox.Y,
-                                      (int)inputBox.Width, (int)inputBox.Height,
-                                      Color.DarkBlue);
-            Raylib.DrawText(inputText, (int)inputBox.X + 5, (int)inputBox.Y + 10, 20,
-                            Color.Black);
-
-            Raylib.DrawText("Enter Port:", screenWidth / 2 + 40, screenHeight / 2 - 40, 20, Color.DarkBlue); 
-            Rectangle portInputBox = new((float)screenWidth / 3 + 300, (float)screenHeight / 2, 100, 40); 
-            Raylib.DrawRectangleRec(portInputBox, isEditingPort ? Color.White : Color.LightGray);
-            Raylib.DrawRectangleLines((int)portInputBox.X, (int)portInputBox.Y, (int)portInputBox.Width, (int)portInputBox.Height, Color.DarkBlue);
-            Raylib.DrawText(inputPortText, (int)portInputBox.X + 5, (int)portInputBox.Y + 10, 20, Color.Black);
-
-
-            if (Raylib.IsMouseButtonReleased(MouseButton.Left))
-            {
-                if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), inputBox))
-                {
-                    isEditingIp = true;
-                    isEditingPort = false;
-                }
-                else if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), portInputBox))
-                {
-                    isEditingIp = false;
-                    isEditingPort = true;
-                }
-                else
-                {
-                    isEditingIp = false;
-                    isEditingPort = false;
-                }
-            }
-
-            if (isEditingIp || isEditingPort) 
-            {
-                HandleTextInput();
-            }
-
-            Rectangle connectButton = new(
-                (float)screenWidth / 2 - 80, (float)screenHeight / 2 + 60, 160, 40);
-            if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(),
-                                              connectButton) &&
-                Raylib.IsMouseButtonReleased(MouseButton.Left))
-            {
-                if (int.TryParse(inputPortText, out int portValue) && portValue > 0 && portValue <= 65535)
-                {
-                    NetworkManager.Instance.ConnectToServer(inputText, portValue);
-                }
-                else
-                {
-                    Console.WriteLine("Invalid port number. Please enter a number between 1 and 65535.");
-                }
-            }
-
-            Raylib.DrawRectangleRec(connectButton, Color.Blue);
-            Raylib.DrawText("Connect", (int)connectButton.X + 40,
-                            (int)connectButton.Y + 10, 20, Color.White);
-
-            Rectangle backButton =
-                new((float)screenWidth / 3, (float)screenHeight / 2 + 120, 100, 40);
-            if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(),
-                                              backButton) &&
-                Raylib.IsMouseButtonReleased(MouseButton.Left))
-            {
-                currentState = GameState.MainMenu;
-                isEditingIp = false;
-            }
-
-            Raylib.DrawRectangleRec(backButton, Color.Gray);
-            Raylib.DrawText("Back", (int)backButton.X + 30, (int)backButton.Y + 10,
-                            20, Color.White);
             gameTimer.Reset();
         }
 
@@ -264,7 +187,6 @@ public class GameStateManager
 
         if ((Raylib.IsKeyPressedRepeat(KeyboardKey.Backspace) || Raylib.IsKeyPressed(KeyboardKey.Backspace)))
         {
-            int key = Raylib.GetCharPressed();
             while (key > 0)
             {
                 if (isEditingIp)

--- a/src/WaterWizard.Client/gamestates/ConnectingMenuState.cs
+++ b/src/WaterWizard.Client/gamestates/ConnectingMenuState.cs
@@ -12,14 +12,14 @@ public class ConnectingMenuState : IGameState
     private void DrawConnectMenu(GameStateManager manager)
     {
         Raylib.DrawText("Enter IP Address:", manager.screenWidth / 3, manager.screenHeight / 2 - 40, 20, Color.DarkBlue);
-        Rectangle inputBox = new(manager.screenWidth / 3, manager.screenHeight / 2, 250, 40); 
+        Rectangle inputBox = new((float)manager.screenWidth / 3, (float)manager.screenHeight / 2, 250, 40); 
         Raylib.DrawRectangleRec(inputBox, manager.IsEditingIp() ? Color.White : Color.LightGray);
         Raylib.DrawRectangleLinesEx(inputBox, 1, Color.DarkBlue);
         Raylib.DrawText(manager.GetInputText(), (int)inputBox.X + 5, (int)inputBox.Y + 10, 20, Color.Black);
 
         int portInputX = (int)inputBox.X + (int)inputBox.Width + 20; 
         Raylib.DrawText("Enter Port:", portInputX, manager.screenHeight / 2 - 40, 20, Color.DarkBlue);
-        Rectangle portInputBox = new(portInputX, manager.screenHeight / 2f, 100, 40);
+        Rectangle portInputBox = new(portInputX, (float)manager.screenHeight / 2, 100, 40);
         Raylib.DrawRectangleRec(portInputBox, manager.IsEditingPort() ? Color.White : Color.LightGray); 
         Raylib.DrawRectangleLinesEx(portInputBox, 1, Color.DarkBlue);
         Raylib.DrawText(manager.GetInputPortText(), (int)portInputBox.X + 5, (int)portInputBox.Y + 10, 20, Color.Black); 

--- a/src/WaterWizard.Client/gamestates/ConnectingMenuState.cs
+++ b/src/WaterWizard.Client/gamestates/ConnectingMenuState.cs
@@ -11,33 +11,67 @@ public class ConnectingMenuState : IGameState
 
     private void DrawConnectMenu(GameStateManager manager)
     {
-        Raylib.DrawText("Enter IP Address to Connect:", manager.screenWidth / 3, manager.screenHeight / 3, 20, Color.DarkBlue);
-        Rectangle inputBox = new((float)manager.screenWidth / 3, (float)manager.screenHeight / 2, 300, 40);
+        Raylib.DrawText("Enter IP Address:", manager.screenWidth / 3, manager.screenHeight / 2 - 40, 20, Color.DarkBlue);
+        Rectangle inputBox = new(manager.screenWidth / 3, manager.screenHeight / 2, 250, 40); 
         Raylib.DrawRectangleRec(inputBox, manager.IsEditingIp() ? Color.White : Color.LightGray);
-        Raylib.DrawRectangleLines((int)inputBox.X, (int)inputBox.Y, (int)inputBox.Width, (int)inputBox.Height, Color.DarkBlue);
+        Raylib.DrawRectangleLinesEx(inputBox, 1, Color.DarkBlue);
         Raylib.DrawText(manager.GetInputText(), (int)inputBox.X + 5, (int)inputBox.Y + 10, 20, Color.Black);
-        if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), inputBox) && Raylib.IsMouseButtonReleased(MouseButton.Left))
+
+        int portInputX = (int)inputBox.X + (int)inputBox.Width + 20; 
+        Raylib.DrawText("Enter Port:", portInputX, manager.screenHeight / 2 - 40, 20, Color.DarkBlue);
+        Rectangle portInputBox = new(portInputX, manager.screenHeight / 2f, 100, 40);
+        Raylib.DrawRectangleRec(portInputBox, manager.IsEditingPort() ? Color.White : Color.LightGray); 
+        Raylib.DrawRectangleLinesEx(portInputBox, 1, Color.DarkBlue);
+        Raylib.DrawText(manager.GetInputPortText(), (int)portInputBox.X + 5, (int)portInputBox.Y + 10, 20, Color.Black); 
+
+        if (Raylib.IsMouseButtonReleased(MouseButton.Left))
         {
-            manager.SetEditingIp(true);
+            if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), inputBox))
+            {
+                manager.SetEditingIp(true);
+                manager.SetEditingPort(false); 
+            }
+            else if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), portInputBox))
+            {
+                manager.SetEditingPort(true);
+                manager.SetEditingIp(false); 
+            }
+            else
+            {
+                manager.SetEditingIp(false);
+                manager.SetEditingPort(false);
+            }
         }
-        if (manager.IsEditingIp())
+
+        if (manager.IsEditingIp() || manager.IsEditingPort()) 
         {
             manager.HandleTextInput();
         }
-        Rectangle connectButton = new Rectangle((float)manager.screenWidth / 2 - 80, (float)manager.screenHeight / 2 + 60, 160, 40);
+
+        Rectangle connectButton = new Rectangle(manager.screenWidth / 2f - 80, manager.screenHeight / 2f + 60, 160, 40);
         if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), connectButton) && Raylib.IsMouseButtonReleased(MouseButton.Left))
         {
-            NetworkManager.Instance.ConnectToServer(manager.GetInputText(), 7777);
+            if (int.TryParse(manager.GetInputPortText(), out int port))
+            {
+                NetworkManager.Instance.ConnectToServer(manager.GetInputText(), port);
+            }
+            else
+            {
+                NetworkManager.Instance.ConnectToServer(manager.GetInputText(), 7777); 
+                Console.WriteLine("Invalid port, using default 7777"); 
+            }
         }
         Raylib.DrawRectangleRec(connectButton, Color.Blue);
-        Raylib.DrawText("Connect", (int)connectButton.X + 40, (int)connectButton.Y + 10, 20, Color.White);
-        Rectangle backButton = new((float)manager.screenWidth / 3, (float)manager.screenHeight / 2 + 120, 100, 40);
+        Raylib.DrawText("Connect", (int)connectButton.X + (160 - Raylib.MeasureText("Connect", 20)) / 2, (int)connectButton.Y + 10, 20, Color.White);
+
+        Rectangle backButton = new(manager.screenWidth / 2f - 80, manager.screenHeight / 2f + 120, 160, 40);
         if (Raylib.CheckCollisionPointRec(Raylib.GetMousePosition(), backButton) && Raylib.IsMouseButtonReleased(MouseButton.Left))
         {
             manager.SetStateToMainMenu();
             manager.SetEditingIp(false);
+            manager.SetEditingPort(false); 
         }
         Raylib.DrawRectangleRec(backButton, Color.Gray);
-        Raylib.DrawText("Back", (int)backButton.X + 30, (int)backButton.Y + 10, 20, Color.White);
+        Raylib.DrawText("Back", (int)backButton.X + (160 - Raylib.MeasureText("Back", 20)) / 2, (int)backButton.Y + 10, 20, Color.White);
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to allow users to input both an IP address and a port number for server connections in the `WaterWizard.Client` project. The changes include adding a new input field for the port, updating the UI to display this field, and modifying the connection logic to validate and use the provided port number.

### Input Handling Enhancements:
* Added a new `inputPortText` field and `isEditingPort` flag to manage user input for the port number. (`src/WaterWizard.Client/GameStateManager.cs`, [src/WaterWizard.Client/GameStateManager.csL51-R54](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L51-R54))
* Updated the `HandleTextInput` method to handle separate input logic for the IP address and port number, including character restrictions and backspace functionality. (`src/WaterWizard.Client/GameStateManager.cs`, [src/WaterWizard.Client/GameStateManager.csL627-R693](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L627-R693))

### UI Updates:
* Modified the `DrawConnectMenu` method to include a new input box for the port number, along with corresponding labels and visual elements. (`src/WaterWizard.Client/GameStateManager.cs`, [[1]](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L407-R410) [[2]](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L420-R466)

### Connection Logic:
* Updated the connection logic to validate the port number (ensuring it is within the valid range of 1–65535) before attempting to connect to the server. Added error handling for invalid port inputs. (`src/WaterWizard.Client/GameStateManager.cs`, [src/WaterWizard.Client/GameStateManager.csL420-R466](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0L420-R466)