### PR TITLE
Add continuous deployment pipeline for automated releases

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -1,0 +1,56 @@
+name: CD Release
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write 
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run NUKE Build
+        run: ./build.sh Clean Compile Test
+
+      - name: Publish Server
+        run: dotnet publish src/WaterWizard.Server/WaterWizard.Server.csproj -c Release -o ./publish
+
+      - name: Get version from project
+        id: get_version
+        run: |
+          VERSION=$(grep -m1 '<Version>' src/WaterWizard.Server/WaterWizard.Server.csproj | sed -E 's/.*<Version>(.+)<\/Version>.*/\1/')
+          if [ -z "$VERSION" ]; then
+            VERSION="v0.0.$GITHUB_RUN_NUMBER"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          files: ./publish/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous deployment (CD). The workflow automates the build, test, publish, and release process for the `WaterWizard.Server` project.

### New Continuous Deployment Workflow:

* `.github/workflows/cd-pipeline.yml`: Added a `CD Release` workflow triggered on pushes to the `main` branch. The workflow includes steps to:
  - Check out the repository (`actions/checkout@v4`).
  - Set up the .NET SDK (`actions/setup-dotnet@v4`) with version `8.0.x`.
  - Run the NUKE build script for cleaning, compiling, and testing the project.
  - Publish the `WaterWizard.Server` project in Release configuration.
  - Extract the version number from the project file or generate a fallback version.
  - Create a GitHub release with the extracted version as the tag and release name.
  - Upload the published assets to the release.