### PR TITLE
F152 5seconds timer for game start

### DIFF
--- a/src/WaterWizard.Client/NetworkManager.cs
+++ b/src/WaterWizard.Client/NetworkManager.cs
@@ -110,6 +110,7 @@ public class NetworkManager
                                $"Player_{playerAddress.Split(':').LastOrDefault()}";
 
             RemovePlayerByAddress(playerAddress);
+            LobbyCountdownSeconds = null;
             BroadcastSystemMessage($"{playerName} disconnected ({disconnectInfo.Reason}).");
             UpdatePlayerList();
         };
@@ -577,6 +578,7 @@ public class NetworkManager
             GameStateManager.Instance.ChatLog.AddMessage(
                 $"Disconnected from server: {reasonExplanation}"
             );
+            LobbyCountdownSeconds = null;
         };
 
         clientListener.NetworkErrorEvent += (endPoint, error) =>
@@ -764,6 +766,7 @@ public class NetworkManager
         client?.Stop();
         discoveredLobbies.Clear();
         connectedPlayers.Clear();
+        LobbyCountdownSeconds = null; 
     }
 
     private void BroadcastSystemMessage(string message)

--- a/src/WaterWizard.Client/NetworkManager.cs
+++ b/src/WaterWizard.Client/NetworkManager.cs
@@ -26,6 +26,12 @@ public class NetworkManager
     private GameSessionId? sessionId;
     public GameSessionId? SessionId => sessionId;
 
+    /// <summary>
+    /// Stores the current lobby countdown seconds (null if no countdown active).
+    /// </summary>
+    public int? LobbyCountdownSeconds { get; private set; }
+
+    
     private NetworkManager() { }
 
     /// <summary>
@@ -133,6 +139,26 @@ public class NetworkManager
         }
     }
 
+    /// <summary>
+    /// Verarbeitet den Countdown für die Lobby.
+    /// </summary>
+    /// <param name="reader">Der NetPacketReader, der die Nachricht enthält.</param>
+    /// <returns></returns>
+    public void HandleLobbyCountdown(NetPacketReader reader)
+    {
+        int secondsLeft = reader.GetInt();
+        if (secondsLeft <= 0)
+        {
+            LobbyCountdownSeconds = null;
+        }
+        else
+        {
+            LobbyCountdownSeconds = secondsLeft;
+        }
+        Console.WriteLine($"[Client] Lobby countdown: {LobbyCountdownSeconds}");
+    }
+
+
     private void HandleServerReceiveEvent(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
     {
         try
@@ -148,6 +174,9 @@ public class NetworkManager
                     break;
                 case "ChatMessage":
                     string chatMsg = reader.GetString();
+                    break;
+                case "LobbyCountdown":
+                    HandleLobbyCountdown(reader);
                     break;
                 case "PlayerJoin":
                     string playerName = reader.GetString(); // Name sent by the client
@@ -639,6 +668,9 @@ public class NetworkManager
             {
                 case "StartGame":
                     GameStateManager.Instance.SetStateToInGame();
+                    break;
+                case "LobbyCountdown":
+                    HandleLobbyCountdown(reader);
                     break;
                 case "EnterLobby":
                     string receivedSessionId = reader.GetString();

--- a/src/WaterWizard.Client/gamescreen/PreStartLobbyTimer.cs
+++ b/src/WaterWizard.Client/gamescreen/PreStartLobbyTimer.cs
@@ -1,0 +1,26 @@
+using Raylib_cs;
+
+namespace WaterWizard.Client.gamescreen;
+
+/// <summary>
+/// Zeichnet den Countdown für den Spielstart in der Lobby.
+/// /// </summary>
+public static class PreStartLobbyTimer
+{
+    /// <summary>
+    /// Zeichnet den Countdown für den Spielstart in der Lobby.
+    /// </summary>
+    /// <param name="manager">Der GameStateManager, der den Zustand verwaltet.</param>
+    /// <returns></returns>
+    public static void DrawCountdown(GameStateManager manager)
+    {
+        var countdown = NetworkManager.Instance.LobbyCountdownSeconds;
+        Console.WriteLine($"[DrawCountdown] Called. Countdown value: {countdown}");
+        if (countdown.HasValue && countdown.Value > 0)
+        {
+            string countdownText = $"Game starts in {countdown.Value}...";
+            int countdownWidth = Raylib.MeasureText(countdownText, 40);
+            Raylib.DrawText(countdownText, (manager.screenWidth - countdownWidth) / 2, manager.screenHeight / 2, 40, Color.Red);
+        }
+    }
+}

--- a/src/WaterWizard.Client/gamestates/PreStartLobbyState.cs
+++ b/src/WaterWizard.Client/gamestates/PreStartLobbyState.cs
@@ -1,4 +1,5 @@
 using Raylib_cs;
+using WaterWizard.Client.gamescreen;
 
 namespace WaterWizard.Client.gamestates;
 
@@ -36,6 +37,7 @@ public class PreStartLobbyState : IGameState
         int buttonHeight = 50;
         int buttonX = (int)(availableWidth - buttonWidth) / 2;
         bool isHost = NetworkManager.Instance.IsHost();
+        PreStartLobbyTimer.DrawCountdown(manager);
         if (isHost)
         {
             Rectangle startButton = new Rectangle(buttonX, actionButtonY, buttonWidth, buttonHeight);

--- a/src/WaterWizard.Server/Program.cs
+++ b/src/WaterWizard.Server/Program.cs
@@ -121,6 +121,8 @@ static class Program
                         }
                         if (ConnectedPlayers.Count == 0)
                         {
+                            BroadcastCountdownReset(server);
+
                             Log("[Server] Letzter Spieler hat die Verbindung getrennt.");
                             gameStateManager.ChangeState(new LobbyState(server));
 
@@ -272,5 +274,22 @@ static class Program
                 recipientPeer.Send(writer, DeliveryMethod.ReliableOrdered);
             }
         }
+    }
+
+    /// <summary>
+    /// Broadcastet den Countdown an alle verbundenen Spieler.
+    /// /// </summary>
+    /// <param name="secondsLeft">Die verbleibenden Sekunden des Countdowns.</param>
+    /// <returns></returns>
+    private static void BroadcastCountdownReset(NetManager server)
+    {
+        var writer = new NetDataWriter();
+        writer.Put("LobbyCountdown");
+        writer.Put(0); // 0 means reset/hide
+        foreach (var peer in server.ConnectedPeerList)
+        {
+            peer.Send(writer, DeliveryMethod.ReliableOrdered);
+        }
+        Log("[Server] Broadcasted countdown reset to all clients.");
     }
 }

--- a/src/WaterWizard.Server/Program.cs
+++ b/src/WaterWizard.Server/Program.cs
@@ -115,10 +115,15 @@ static class Program
                         ConnectedPlayers.Remove(playerAddress);
                         PlacementReadyPlayers.Remove(playerAddress);
                         PlayerNames.Remove(playerAddress);
-
+                        if (gameStateManager.CurrentState is LobbyState lobbyState)
+                        {
+                            lobbyState.ResetCountdown();
+                        }
                         if (ConnectedPlayers.Count == 0)
                         {
                             Log("[Server] Letzter Spieler hat die Verbindung getrennt.");
+                            gameStateManager.ChangeState(new LobbyState(server));
+
                             if (_gameSessionTimer != null && _gameSessionTimer.IsRunning)
                             {
                                 Log("[Server] Stoppe den Spiel-Timer.");

--- a/src/WaterWizard.Server/ServerGameStates/LobbyState.cs
+++ b/src/WaterWizard.Server/ServerGameStates/LobbyState.cs
@@ -125,4 +125,21 @@ public class LobbyState : IServerGameState
         }
         Console.WriteLine("[Server] Countdown timer reset and reset broadcasted.");
     }
+
+    /// <summary>
+    /// Broadcastet eine Countdown-Reset-Nachricht an alle verbundenen Spieler.
+    /// </summary>
+    /// <param name="server">Der NetManager-Server.</param>
+    /// <returns></returns>
+    private static void BroadcastCountdownReset(NetManager server)
+    {
+        var writer = new NetDataWriter();
+        writer.Put("LobbyCountdown");
+        writer.Put(0); 
+        foreach (var peer in server.ConnectedPeerList)
+        {
+            peer.Send(writer, DeliveryMethod.ReliableOrdered);
+        }
+        Console.WriteLine("[Server] Broadcasted countdown reset to all clients.");
+    }
 }

--- a/src/WaterWizard.Server/ServerGameStates/LobbyState.cs
+++ b/src/WaterWizard.Server/ServerGameStates/LobbyState.cs
@@ -9,6 +9,9 @@ using LiteNetLib.Utils;
 public class LobbyState : IServerGameState
 {
     private readonly NetManager server;
+    private Timer? countdownTimer;
+    private int countdownSeconds = 5;
+    
     public LobbyState(NetManager server) { this.server = server; }
 
     /// <summary>
@@ -29,6 +32,12 @@ public class LobbyState : IServerGameState
         Console.WriteLine($"[LobbyState] HandleNetworkEvent called for peer {peer} with messageType {MessageType}. Reader position: {reader.Position}");
         // TODO: Implement network event handling for the lobby
         // For example, receiving "PlayerReady" messages and then calling CheckAllPlayersReady
+        if (MessageType == "PlayerReady")
+        {
+            string playerAddress = peer.ToString();
+            Program.ConnectedPlayers[playerAddress] = true;
+            CheckAllPlayersReady(manager);
+        }
     }
 
     public void CheckAllPlayersReady(ServerGameStateManager manager)
@@ -36,12 +45,84 @@ public class LobbyState : IServerGameState
         if (Program.ConnectedPlayers.Count > 0 && Program.ConnectedPlayers.Values.All(ready => ready))
         {
             Console.WriteLine("[Server] All players are ready. Transitioning to Placement State.");
-            manager.ChangeState(new PlacementState(this.server)); // Use the server instance from the LobbyState
+            StartCountdown(manager);
         }
         else
         {
             int readyCount = Program.ConnectedPlayers.Values.Count(ready => ready);
             Console.WriteLine($"[Server] Waiting for players: {readyCount}/{Program.ConnectedPlayers.Count} ready.");
+            if (countdownTimer != null)
+            {
+                ResetCountdown();
+                Console.WriteLine("[Server] Countdown reset due to player not ready.");
+            }
+            if (Program.ConnectedPlayers.Count == 0)
+            {
+                ResetCountdown();
+                Console.WriteLine("[Server] Countdown reset due to no player Connected.");
+            }
         }
+    }
+
+    /// <summary>
+    /// Startet einen Countdown für den Spielbeginn.
+    /// </summary>
+    /// <param name="manager">Der ServerGameStateManager, der den Zustand verwaltet.</param>
+    /// <returns></returns>
+    public void StartCountdown(ServerGameStateManager manager)
+    {
+        countdownSeconds = 5;
+        countdownTimer?.Dispose();
+        countdownTimer = new Timer(_ =>
+        {
+            if (countdownSeconds > 0)
+            {
+                BroadcastCountdown(countdownSeconds);
+                countdownSeconds--;
+            }
+            else
+            {
+                countdownTimer?.Dispose();
+                Console.WriteLine("[Server] Countdown finished. Starting game.");
+                manager.ChangeState(new PlacementState(server)); 
+            }
+        }, null, 0, 1000);
+    }
+
+    /// <summary>
+    /// Broadcastet den Countdown an alle verbundenen Spieler.
+    /// </summary>
+    /// <param name="secondsLeft">Die verbleibenden Sekunden des Countdowns.</param>
+    /// <returns></returns>
+    private void BroadcastCountdown(int secondsLeft)
+    {
+        var writer = new NetDataWriter();
+        writer.Put("LobbyCountdown");
+        writer.Put(secondsLeft);
+        foreach (var peer in server.ConnectedPeerList)
+        {
+            peer.Send(writer, DeliveryMethod.ReliableOrdered);
+        }
+        Console.WriteLine($"[Server] Broadcasted countdown: {secondsLeft}");
+    }
+
+    /// <summary>
+    /// Setzt den Countdown zurück.
+    /// </summary>
+    /// <returns></returns>
+    public void ResetCountdown()
+    {
+        countdownTimer?.Dispose();
+        countdownTimer = null;
+        countdownSeconds = 5;
+
+        var writer = new NetDataWriter();
+        writer.Put("LobbyCountdown");
+        writer.Put(0); 
+        foreach (var peer in server.ConnectedPeerList)
+        {
+            peer.Send(writer, DeliveryMethod.ReliableOrdered);
+        }
+        Console.WriteLine("[Server] Countdown timer reset and reset broadcasted.");
     }
 }


### PR DESCRIPTION
This pull request introduces a lobby countdown feature for the game, allowing players to see a countdown timer in the lobby before the game starts. The changes span both the client and server codebases, adding functionality to manage, broadcast, and display the countdown. Below are the most important changes grouped by theme:

### Client-Side Changes

* **Lobby Countdown Management:**
  - Added a new `LobbyCountdownSeconds` property in `NetworkManager` to store the countdown value. It is reset to `null` when players disconnect, the client shuts down, or when the server sends a reset signal. (`src/WaterWizard.Client/NetworkManager.cs`, [[1]](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R29-R34) [[2]](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R113) [[3]](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R581) [[4]](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R769)
  - Implemented `HandleLobbyCountdown` to process countdown messages from the server and update the `LobbyCountdownSeconds` property. (`src/WaterWizard.Client/NetworkManager.cs`, [src/WaterWizard.Client/NetworkManager.csR143-R162](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R143-R162))
  - Integrated handling for "LobbyCountdown" messages in the network receive event handlers. (`src/WaterWizard.Client/NetworkManager.cs`, [[1]](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R179-R181) [[2]](diffhunk://#diff-6d988f9d244593c7e5a82107003b4914057736d620829e0815683dbfa7fcde17R674-R676)

* **Lobby Countdown Display:**
  - Added `PreStartLobbyTimer` to render the countdown on the lobby screen using Raylib. (`src/WaterWizard.Client/gamescreen/PreStartLobbyTimer.cs`, [src/WaterWizard.Client/gamescreen/PreStartLobbyTimer.csR1-R26](diffhunk://#diff-0612d5bcaae562d8b7dfa43922772044af7a70c247cbe60e6262bd2f011b8472R1-R26))
  - Updated `PreStartLobbyState` to call `PreStartLobbyTimer.DrawCountdown` during the lobby rendering process. (`src/WaterWizard.Client/gamestates/PreStartLobbyState.cs`, [[1]](diffhunk://#diff-ef28efcbca96262c5b948135b6fdd91de81f4c658523eb4e271054dc3ccb328fR2) [[2]](diffhunk://#diff-ef28efcbca96262c5b948135b6fdd91de81f4c658523eb4e271054dc3ccb328fR40)

### Server-Side Changes

* **Countdown Management in Lobby State:**
  - Added a countdown timer in `LobbyState`, which broadcasts the countdown value to all connected players at one-second intervals. The countdown ends by transitioning to the next game state. (`src/WaterWizard.Server/ServerGameStates/LobbyState.cs`, [[1]](diffhunk://#diff-986fb9eccea2ef71e351070c2948dc149a95628df73771b06437560d5a64aa2dR12-R14) [[2]](diffhunk://#diff-986fb9eccea2ef71e351070c2948dc149a95628df73771b06437560d5a64aa2dR35-R143)
  - Implemented methods to start, reset, and broadcast the countdown. Countdown resets are triggered if all players are not ready or if no players are connected. (`src/WaterWizard.Server/ServerGameStates/LobbyState.cs`, [src/WaterWizard.Server/ServerGameStates/LobbyState.csR35-R143](diffhunk://#diff-986fb9eccea2ef71e351070c2948dc149a95628df73771b06437560d5a64aa2dR35-R143))

* **Global Countdown Reset:**
  - Added a `BroadcastCountdownReset` method in the server program to notify clients to reset/hide the countdown when necessary, such as when the last player disconnects. (`src/WaterWizard.Server/Program.cs`, [[1]](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL118-R128) [[2]](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caR278-R294)