### PR TITLE
Potential fix for code scanning alert no. 660: Useless assignment to local variable

### DIFF
--- a/src/WaterWizard.Client/NetworkManager.cs
+++ b/src/WaterWizard.Client/NetworkManager.cs
@@ -176,7 +176,7 @@ public class NetworkManager
                     HandlePlayerReadyStatus(peer, messageType == "PlayerReady");
                     break;
                 case "ChatMessage":
-                    string chatMsg = reader.GetString();
+                    reader.GetString(); // Read the chat message (side effects, if any, are preserved)
                     break;
                 case "LobbyCountdown":
                     HandleLobbyCountdown(reader);

--- a/src/WaterWizard.Client/NetworkManager.cs
+++ b/src/WaterWizard.Client/NetworkManager.cs
@@ -176,7 +176,7 @@ public class NetworkManager
                     HandlePlayerReadyStatus(peer, messageType == "PlayerReady");
                     break;
                 case "ChatMessage":
-                    reader.GetString(); // Read the chat message (side effects, if any, are preserved)
+                    reader.GetString();
                     break;
                 case "LobbyCountdown":
                     HandleLobbyCountdown(reader);


### PR DESCRIPTION
Potential fix for [https://github.com/maxk2807/WaterWizards/security/code-scanning/660](https://github.com/maxk2807/WaterWizards/security/code-scanning/660)

To fix the issue, the assignment to `chatMsg` should be removed. If the `reader.GetString()` method is required for its side effects, it can be called without assigning the result to a variable. If the `ChatMessage` case is incomplete and intended to process the message, additional logic should be implemented to handle the `chatMsg` value appropriately.

In this case, since there is no indication of further processing for `chatMsg`, the simplest fix is to remove the assignment entirely. If future functionality is planned, a comment can be added to indicate that the case is a placeholder.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
