### PR TITLE
fixed hardcoded player count server would crash if less than two play…

### DIFF
--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -25,9 +25,15 @@ public class GameState
     public List<Cards> Graveyard { get; private set; }
 
     public GameState(NetManager server, ServerGameStateManager manager)
-    {        
-        players[0] = server.ConnectedPeerList[0];
-        players[1] = server.ConnectedPeerList[1];
+    {       
+        int connectedCount = server.ConnectedPeerList.Count;
+        if (connectedCount < 1 || connectedCount > 2)
+            throw new InvalidOperationException("Game requires 1 or 2 connected players.");
+
+        players = new NetPeer[connectedCount];
+        for (int i = 0; i < connectedCount; i++)
+            players[i] = server.ConnectedPeerList[i];
+
         boards = InitBoards();
         hands = [[], []];
         ActiveCards = [];


### PR DESCRIPTION
This pull request updates the `GameState` class in `src/WaterWizard.Server/GameState.cs` to improve the handling of connected players during initialization. The most important change ensures that the game properly validates the number of connected players and dynamically initializes the `players` array based on the actual count.

### Improvements to player initialization:

* Added a validation check to ensure the game only starts with 1 or 2 connected players, throwing an `InvalidOperationException` if this condition is not met.
* Updated the `players` array to be dynamically sized based on the number of connected players, replacing the previous hardcoded assignment for two players.