### PR TITLE
Fix output directory names for Windows and MacOS client/server publis…

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -26,10 +26,16 @@ jobs:
         run: ./build.sh Clean Compile Test
 
       - name: Publish Client (Windows)
-        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r win-x64 --self-contained true -o ./publish/win
+        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r win-x64 --self-contained true -o ./publish/win-client
+
+      - name: Publish Server (Windows)
+        run: dotnet publish src/WaterWizard.Server/WaterWizard.Server.csproj -c Release -r win-x64 --self-contained true -o ./publish/win-server
 
       - name: Publish Client (MacOS)
-        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r osx-x64 --self-contained true -o ./publish/osx
+        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r osx-x64 --self-contained true -o ./publish/osx-client
+
+      - name: Publish Server (MacOS)
+        run: dotnet publish src/WaterWizard.Server/WaterWizard.Server.csproj -c Release -r osx-x64 --self-contained true -o ./publish/osx-server
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
This pull request updates the Continuous Deployment pipeline in `.github/workflows/cd-pipeline.yml` to include separate publishing steps for both the client and server applications, ensuring better organization of output directories.

### Updates to the CD pipeline:

* **Windows publishing:** Adjusted the output directory for the client application to `./publish/win-client` and added a new step to publish the server application to `./publish/win-server`.
* **MacOS publishing:** Adjusted the output directory for the client application to `./publish/osx-client` and added a new step to publish the server application to `./publish/osx-server`.