### PR TITLE
Refactor CD pipeline to improve executable publishing and add debug o…

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -26,24 +26,46 @@ jobs:
         run: ./build.sh Clean Compile Test
 
       - name: Publish Client (Windows)
-        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r win-x64 --self-contained true -o ./publish/win-client
+        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r win-x64 --self-contained true -o ./publish/win --verbosity normal
 
       - name: Publish Server (Windows)
         run: dotnet publish src/WaterWizard.Server/WaterWizard.Server.csproj -c Release -r win-x64 --self-contained true -o ./publish/win-server
 
       - name: Publish Client (MacOS)
-        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r osx-x64 --self-contained true -o ./publish/osx-client
+        run: dotnet publish src/WaterWizard.Client/WaterWizard.Client.csproj -c Release -r osx-x64 --self-contained true -o ./publish/osx --verbosity normal
 
       - name: Publish Server (MacOS)
         run: dotnet publish src/WaterWizard.Server/WaterWizard.Server.csproj -c Release -r osx-x64 --self-contained true -o ./publish/osx-server
+
+      - name: Debug - List published files
+        run: |
+          echo "Windows publish contents:"
+          ls -la ./publish/win/ || echo "Windows publish directory not found"
+          echo "MacOS publish contents:"
+          ls -la ./publish/osx/ || echo "MacOS publish directory not found"
 
       - name: Prepare release assets
         run: |
           mkdir release-assets
 
-          # Copy only the binaries you want to release
-          cp ./publish/win/WaterWizard.Client.exe release-assets/
-          cp ./publish/osx/WaterWizard.Client release-assets/WaterWizard.Client.BinaryMacOs.Client
+          # Find the actual executable names
+          WIN_EXE=$(find ./publish/win -name "*.exe" -type f | head -1)
+          OSX_EXE=$(find ./publish/osx -type f -executable | grep -v "\.dll$" | grep -v "\.so$" | head -1)
+          
+          if [ -n "$WIN_EXE" ]; then
+            cp "$WIN_EXE" release-assets/WaterWizard.Client.exe
+          else
+            echo "Warning: No Windows executable found"
+          fi
+          
+          if [ -n "$OSX_EXE" ]; then
+            cp "$OSX_EXE" release-assets/WaterWizard.Client.MacOS
+          else
+            echo "Warning: No MacOS executable found"
+          fi
+          
+          echo "Release assets:"
+          ls -la release-assets/
 
       - name: Get and increment version if needed
         id: get_version


### PR DESCRIPTION
This pull request updates the `.github/workflows/cd-pipeline.yml` file to improve the publishing process for Windows and MacOS builds, enhance debugging capabilities, and make the release asset preparation more robust. The most important changes include adding verbosity to the `dotnet publish` commands, introducing debug steps to list published files, and dynamically identifying executable files for release assets.

### Improvements to publishing process:
* Updated the `dotnet publish` commands for Windows and MacOS clients to include the `--verbosity normal` flag for better visibility during the build process.

### Debugging enhancements:
* Added a new step to list the contents of the published directories (`./publish/win/` and `./publish/osx/`) to aid in debugging. This step includes fallback messages if the directories are not found.

### Robust release asset preparation:
* Modified the script to dynamically locate executable files for Windows and MacOS clients using `find` and filtering criteria, ensuring the correct files are copied to the `release-assets` directory. Added warnings if no executables are found.