### PR TITLE
Add player readiness check and limit to two players in LobbyState

### DIFF
--- a/src/WaterWizard.Server/Program.cs
+++ b/src/WaterWizard.Server/Program.cs
@@ -263,7 +263,7 @@ static class Program
         }
     }
 
-    private static void SendPlayerList(NetManager? server)
+    public static void SendPlayerList(NetManager? server)
     {
         if (server == null)
             return;

--- a/src/WaterWizard.Server/ServerGameStates/LobbyState.cs
+++ b/src/WaterWizard.Server/ServerGameStates/LobbyState.cs
@@ -51,8 +51,40 @@ public class LobbyState : IServerGameState
         }
     }
 
+    /// <summary>
+    /// Überprüft, ob alle Spieler bereit sind, und startet den Countdown für den Spielbeginn.
+    /// </summary>
+    /// <param name="server">Der NetManager-Server für die Netzwerkkommunikation.</param>
     public void CheckAllPlayersReady(ServerGameStateManager manager)
     {
+        if (Program.ConnectedPlayers.Count > 2)
+        {
+            Console.WriteLine($"[Server] Too many players connected ({Program.ConnectedPlayers.Count}). Maximum is 2. Resetting all players to not ready.");
+
+            var playerKeys = Program.ConnectedPlayers.Keys.ToList();
+            foreach (var playerKey in playerKeys)
+            {
+                Program.ConnectedPlayers[playerKey] = false;
+            }
+
+            if (countdownTimer != null)
+            {
+                ResetCountdown();
+            }
+
+            Program.SendPlayerList(server);
+
+            var systemMessageWriter = new NetDataWriter();
+            systemMessageWriter.Put("SystemMessage");
+            systemMessageWriter.Put("Too many players! Maximum 2 players allowed. All players reset to not ready.");
+            foreach (var peer in server.ConnectedPeerList)
+            {
+                peer.Send(systemMessageWriter, DeliveryMethod.ReliableOrdered);
+            }
+
+            return;
+        }
+
         if (
             Program.ConnectedPlayers.Count > 0
             && Program.ConnectedPlayers.Values.All(ready => ready)


### PR DESCRIPTION
This pull request introduces changes to improve the handling of player readiness in the lobby state and makes a method accessible across the application. The most significant updates include adding a mechanism to reset player readiness when too many players are connected and making the `SendPlayerList` method public for broader usability.

### Changes to player readiness handling:

* Added a check in `CheckAllPlayersReady` in `src/WaterWizard.Server/ServerGameStates/LobbyState.cs` to handle scenarios where more than two players are connected. If this condition is met, all players are reset to "not ready," the countdown timer is reset (if active), and a system message is sent to all connected peers explaining the issue. (`[src/WaterWizard.Server/ServerGameStates/LobbyState.csR54-R87](diffhunk://#diff-986fb9eccea2ef71e351070c2948dc149a95628df73771b06437560d5a64aa2dR54-R87)`)

### Changes to method accessibility:

* Changed the `SendPlayerList` method in `src/WaterWizard.Server/Program.cs` from `private` to `public` to allow it to be called from other classes, such as the lobby state logic. (`[src/WaterWizard.Server/Program.csL266-R266](diffhunk://#diff-2601cdfbe7849a1cf89e381890c1acb459d5d9465f7bb83206e29f510409a1caL266-R266)`)