### PR TITLE
Refactor game board and ship logic; add cell state management and dam…

### DIFF
--- a/src/WaterWizard.Client/gamescreen/CellState.cs
+++ b/src/WaterWizard.Client/gamescreen/CellState.cs
@@ -1,0 +1,13 @@
+namespace WaterWizard.Client.Gamescreen;
+
+/// <summary>
+/// CellState enum represents the possible states of a cell in the game board.
+/// </summary>
+public enum CellState
+{
+    Empty,
+    Ship,
+    Hit,
+    Miss,
+    Unknown,
+}

--- a/src/WaterWizard.Client/gamescreen/GameBoard.cs
+++ b/src/WaterWizard.Client/gamescreen/GameBoard.cs
@@ -2,22 +2,10 @@ using System.Numerics;
 using Raylib_cs;
 using WaterWizard.Client.gamescreen.cards;
 using WaterWizard.Client.gamescreen.ships;
-using WaterWizard.Client.network;
-using WaterWizard.Shared;
+using WaterWizard.Client.Gamescreen;
 
 namespace WaterWizard.Client.gamescreen;
 
-/// <summary>
-/// CellState enum represents the possible states of a cell in the game board.
-/// </summary>
-public enum CellState
-{
-    Empty,
-    Ship,
-    Hit,
-    Miss,
-    Unknown,
-}
 
 /// <summary>
 /// GameBoard class represents the game board for the battleship game.
@@ -128,12 +116,11 @@ public class GameBoard
             {
                 int posX = (int)Position.X + x * CellSize;
                 int posY = (int)Position.Y + y * CellSize;
-
-                Color cellColor = GetColorForState(_gridStates[x, y]);
-                Raylib.DrawRectangle(posX, posY, CellSize, CellSize, cellColor);
-
-                Raylib.DrawRectangleLines(posX, posY, CellSize, CellSize, Color.DarkGray);
-
+                
+                Raylib.DrawRectangle(posX, posY, CellSize, CellSize, Color.SkyBlue);
+                
+                Raylib.DrawRectangleLines(posX, posY, CellSize, CellSize, Color.Gray);
+                
                 if (_gridStates[x, y] == CellState.Hit)
                 {
                     Raylib.DrawCircle(
@@ -154,6 +141,7 @@ public class GameBoard
                 }
             }
         }
+        
         foreach (GameShip ship in Ships)
         {
             ship.Draw();
@@ -224,6 +212,15 @@ public class GameBoard
             {
                 _gridStates[x, y] = CellState.Unknown;
             }
+        }
+    }
+
+    // Add method to mark cells as hit by enemy
+    public void MarkCellAsHit(int x, int y, bool wasHit)
+    {
+        if (x >= 0 && x < GridWidth && y >= 0 && y < GridHeight)
+        {
+            _gridStates[x, y] = wasHit ? CellState.Hit : CellState.Miss;
         }
     }
 }

--- a/src/WaterWizard.Client/gamescreen/ships/GameShip.cs
+++ b/src/WaterWizard.Client/gamescreen/ships/GameShip.cs
@@ -11,10 +11,40 @@ public class GameShip(GameScreen gameScreen, int x, int y, ShipType type, int wi
     public int Y = y;
     public int Width = width;
     public int Height = height;
+    
+    public HashSet<(int X, int Y)> DamagedCells { get; private set; } = new();
+    public bool IsDestroyed => DamagedCells.Count >= (Width * Height / (gameScreen.playerBoard!.CellSize * gameScreen.playerBoard.CellSize));
 
+    public void AddDamage(int cellX, int cellY)
+    {
+        DamagedCells.Add((cellX, cellY));
+    }
+
+    /// <summary>
+    /// Draws the ship on the game screen.
+    /// </summary>
     public void Draw()
     {
         Rectangle rec = new(X, Y, Width, Height);
-        Raylib.DrawRectangleRec(rec, Color.DarkPurple);
+
+        Color shipColor = DamagedCells.Count > 0 ? Color.Maroon : Color.DarkPurple;
+        if (IsDestroyed)
+            shipColor = Color.Black;
+
+        Raylib.DrawRectangleRec(rec, shipColor);
+
+        int cellSize = gameScreen.playerBoard!.CellSize;
+        foreach (var (damageX, damageY) in DamagedCells)
+        {
+            int pixelX = X + (damageX * cellSize);
+            int pixelY = Y + (damageY * cellSize);
+
+            Raylib.DrawCircle(
+                pixelX + cellSize / 2,
+                pixelY + cellSize / 2,
+                cellSize / 4,
+                Color.Red
+            );
+        }
     }
 }

--- a/src/WaterWizard.Client/gamescreen/ships/GameShip.cs
+++ b/src/WaterWizard.Client/gamescreen/ships/GameShip.cs
@@ -42,7 +42,7 @@ public class GameShip(GameScreen gameScreen, int x, int y, ShipType type, int wi
             Raylib.DrawCircle(
                 pixelX + cellSize / 2,
                 pixelY + cellSize / 2,
-                cellSize / 4,
+                cellSize / 4f,
                 Color.Red
             );
         }

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -532,17 +532,25 @@ public class GameState
         bool shipDestroyed
     )
     {
-        var writer = new NetDataWriter();
-        writer.Put("AttackResult");
-        writer.Put(x);
-        writer.Put(y);
-        writer.Put(hit);
-        writer.Put(shipDestroyed);
+        var attackerWriter = new NetDataWriter();
+        attackerWriter.Put("AttackResult");
+        attackerWriter.Put(x);
+        attackerWriter.Put(y);
+        attackerWriter.Put(hit);
+        attackerWriter.Put(shipDestroyed);
+        attackerWriter.Put(false); 
+        attacker.Send(attackerWriter, DeliveryMethod.ReliableOrdered);
 
-        attacker.Send(writer, DeliveryMethod.ReliableOrdered);
-        defender.Send(writer, DeliveryMethod.ReliableOrdered);
+        var defenderWriter = new NetDataWriter();
+        defenderWriter.Put("AttackResult");
+        defenderWriter.Put(x);
+        defenderWriter.Put(y);
+        defenderWriter.Put(hit);
+        defenderWriter.Put(shipDestroyed);
+        defenderWriter.Put(true); 
+        defender.Send(defenderWriter, DeliveryMethod.ReliableOrdered);
 
-        Console.WriteLine($"[Server] Attack result sent: hit={hit}, destroyed={shipDestroyed}");
+        Console.WriteLine($"[Server] Attack result sent: attacker sees result, defender sees damage");
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the game logic and rendering for the `WaterWizard` project. Key changes include moving the `CellState` enum to its own file for better modularity, improving the game board's rendering and interaction logic, adding damage tracking and visualization for ships, and refining the communication of attack results between the client and server.

### Refactoring and Code Organization:

* Moved the `CellState` enum from `GameBoard.cs` to a new file, `CellState.cs`, under the `WaterWizard.Client.Gamescreen` namespace for improved modularity and clarity. [[1]](diffhunk://#diff-0a0293e5e1b7724cbeb385f4b1eb2e68f0c53fb0665ed3f9fbddb9cc7edf39d2R1-R13) [[2]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aL5-L20)

### Game Board Enhancements:

* Updated the `Draw` method in `GameBoard.cs` to change the default cell color to `SkyBlue` and the grid line color to `Gray`, improving the visual appearance of the game board.
* Added a new method, `MarkCellAsHit`, to `GameBoard.cs` for marking cells as hit or missed based on attack results.

### Ship Damage and Visualization:

* Introduced damage tracking for ships in `GameShip.cs` using a `DamagedCells` property and an `IsDestroyed` status. Updated the `Draw` method to visually represent damaged and destroyed ships with different colors and damage markers.

### Client-Server Communication:

* Enhanced the `ClientService` class to handle the new `AttackResult` message, updating the game board and ships based on attack outcomes. This includes marking cells as hit/miss and updating ship damage.
* Updated the `SendAttackResult` method in `GameState.cs` to send separate messages to the attacker and defender, providing them with tailored views of the attack result.