### PR TITLE
Reset game timer and lobby countdown on state changes; adjust game st…

### DIFF
--- a/src/WaterWizard.Client/GameStateManager.cs
+++ b/src/WaterWizard.Client/GameStateManager.cs
@@ -191,6 +191,8 @@ public class GameStateManager
     public void SetStateToHostingMenu()
     {
         currentState = new HostingMenuState();
+        gameTimer.Reset();
+        NetworkManager.Instance.LobbyCountdownSeconds = null;
         NetworkManager.Instance.StartHosting();
     }
 

--- a/src/WaterWizard.Client/gamescreen/handler/LobbyHandler.cs
+++ b/src/WaterWizard.Client/gamescreen/handler/LobbyHandler.cs
@@ -203,6 +203,9 @@ public static class LobbyHandler
 
         GameStateManager.Instance.ResetGame();
 
+        NetworkManager.Instance.clientService.clientReady = false;
+        NetworkManager.Instance.LobbyCountdownSeconds = null;
+
         if (NetworkManager.Instance.clientService.client != null && NetworkManager.Instance.clientService.client.FirstPeer != null)
         {
             var joinWriter = new NetDataWriter();

--- a/src/WaterWizard.Client/network/NetworkManager.cs
+++ b/src/WaterWizard.Client/network/NetworkManager.cs
@@ -170,6 +170,10 @@ public class NetworkManager
             : "You fought well, but victory slipped away. Better luck next time!";
 
         Console.WriteLine($"[Client] Game Over - Result: {result}, IsWinner: {isWinner}");
+
+        Instance.clientService.clientReady = false;
+        Instance.LobbyCountdownSeconds = null;
+
         GameStateManager.Instance.SetStateToGameOver(isWinner, winnerMessage);
     }
 

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -642,7 +642,7 @@ public class GameState
                 }
             },
             null,
-            5000,
+            500,
             Timeout.Infinite
         );
     }


### PR DESCRIPTION
This pull request introduces changes to ensure proper reset of client and lobby states across different game transitions and modifies the game-over broadcast delay for improved responsiveness. Key updates focus on resetting client readiness and lobby countdowns during state transitions and reducing the delay for broadcasting game-over messages.

### State Reset Enhancements:
* [`src/WaterWizard.Client/GameStateManager.cs`](diffhunk://#diff-1cfbec72fc58f6c107b124709ba1949a13fee7052e6935fcc5282ed08198ccd0R194-R195): Added `gameTimer.Reset()` and reset `LobbyCountdownSeconds` to `null` in `SetStateToHostingMenu()` to ensure proper initialization when transitioning to the hosting menu.
* [`src/WaterWizard.Client/gamescreen/handler/LobbyHandler.cs`](diffhunk://#diff-73ab7a9753cc0bddebb96b95b8bae25f2a074c83a93759fec0da2917911e641cR206-R208): Reset `clientReady` and `LobbyCountdownSeconds` to `false` and `null`, respectively, in `EnterLobby()` to ensure proper client state when entering a lobby.
* [`src/WaterWizard.Client/network/NetworkManager.cs`](diffhunk://#diff-c6971baf5f7eb3c61c18b4348786fd16f7b28b047fe2bf2eae67457253f2b1dbR173-R176): Reset `clientReady` and `LobbyCountdownSeconds` in `HandleGameOverMessage()` to ensure the client state is properly reset after a game ends.

### Game-Over Responsiveness:
* [`src/WaterWizard.Server/GameState.cs`](diffhunk://#diff-8ba47ea61bca732cdbffdb97c99ae8ad849decb67d25eb52a30ca50c516a15f9L645-R645): Reduced the game-over broadcast delay from 5000ms to 500ms in `BroadcastGameOver()` to improve responsiveness for players receiving game-over notifications.