### PR TITLE
Add GreedHit card implementation and update related classes

### DIFF
--- a/src/WaterWizard.Client/gamescreen/cards/CardStack.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/CardStack.cs
@@ -13,6 +13,7 @@ public class CardStack(GameScreen gameScreen, int x, int y)
     {
         //later calls to Network to get correct Cards
         cards.Add(new(gameScreen, new(Shared.CardVariant.Firebolt)));
+        cards.Add(new(gameScreen, new(Shared.CardVariant.GreedHit)));
     }
 
     public void InitUtility()

--- a/src/WaterWizard.Server/Card/DamageCardFactory.cs
+++ b/src/WaterWizard.Server/Card/DamageCardFactory.cs
@@ -20,6 +20,7 @@ public static class DamageCardFactory
         {
             CardVariant.Firebolt => new FireboltCard(),
             CardVariant.ArcaneMissile => new ArcaneMissileCard(),
+            CardVariant.GreedHit => new GreedHitCard(),
             _ => null,
         };
     }

--- a/src/WaterWizard.Server/Card/GreedHitCard.cs
+++ b/src/WaterWizard.Server/Card/GreedHitCard.cs
@@ -1,0 +1,183 @@
+using System.Numerics;
+using LiteNetLib;
+using LiteNetLib.Utils;
+using WaterWizard.Server.handler;
+using WaterWizard.Server.Interface;
+using WaterWizard.Shared;
+
+namespace WaterWizard.Server.Card;
+
+/// <summary>
+/// Implementation of the GreedHit damage card
+/// Deals damage to a single cell and steals 2 gold from the opponent when it hits a ship
+/// </summary>
+public class GreedHitCard : IDamageCard
+{
+    /// <summary>
+    /// The variant of the card
+    /// </summary>
+    public CardVariant Variant => CardVariant.GreedHit;
+
+    /// <summary>
+    /// The area of effect as a Vector2 (single cell)
+    /// </summary>
+    public Vector2 AreaOfEffect => new(1, 1);
+
+    /// <summary>
+    /// The base damage this card deals
+    /// </summary>
+    public int BaseDamage => 1;
+
+    /// <summary>
+    /// Whether this card has special targeting rules
+    /// </summary>
+    public bool HasSpecialTargeting => false;
+
+    /// <summary>
+    /// The amount of gold stolen when hitting a ship
+    /// </summary>
+    private const int GoldStealAmount = 2;
+
+    /// <summary>
+    /// Executes the damage effect of the GreedHit card
+    /// </summary>
+    /// <param name="gameState">The current game state</param>
+    /// <param name="targetCoords">The coordinates targeted by the card</param>
+    /// <param name="attacker">The attacking player</param>
+    /// <param name="defender">The defending player</param>
+    /// <returns>True if damage was dealt, false otherwise</returns>
+    public bool ExecuteDamage(
+        GameState gameState,
+        Vector2 targetCoords,
+        NetPeer attacker,
+        NetPeer defender
+    )
+    {
+        int x = (int)targetCoords.X;
+        int y = (int)targetCoords.Y;
+
+        var ships = ShipHandler.GetShips(defender);
+        bool hit = false;
+
+        foreach (var ship in ships)
+        {
+            if (x >= ship.X && x < ship.X + ship.Width &&
+                y >= ship.Y && y < ship.Y + ship.Height)
+            {
+                hit = true;
+                bool newDamage = ship.DamageCell(x, y);
+
+                Console.WriteLine($"[Server] GreedHit hit ship at ({ship.X}, {ship.Y}), new damage: {newDamage}");
+
+                HandleGoldSteal(gameState, attacker, defender);
+
+                if (newDamage)
+                {
+                    if (ship.IsDestroyed)
+                    {
+                        Console.WriteLine($"[Server] GreedHit destroyed ship at ({ship.X}, {ship.Y})!");
+                        ShipHandler.SendShipReveal(attacker, ship, gameState);
+                    }
+                    else
+                    {
+                        CellHandler.SendCellReveal(attacker, defender, x, y, true);
+                    }
+                }
+                else
+                {
+                    CellHandler.SendCellReveal(attacker, defender, x, y, true);
+                }
+                break;
+            }
+        }
+
+        if (!hit)
+        {
+            Console.WriteLine($"[Server] GreedHit missed at ({x}, {y})");
+            CellHandler.SendCellReveal(attacker, defender, x, y, false);
+        }
+
+        return hit;
+    }
+
+    /// <summary>
+    /// Handles the gold stealing mechanic
+    /// </summary>
+    /// <param name="gameState">The current game state</param>
+    /// <param name="attacker">The attacking player</param>
+    /// <param name="defender">The defending player</param>
+    private void HandleGoldSteal(GameState gameState, NetPeer attacker, NetPeer defender)
+    {
+        int attackerIndex = gameState.GetPlayerIndex(attacker);
+        int defenderIndex = gameState.GetPlayerIndex(defender);
+
+        if (attackerIndex == -1 || defenderIndex == -1)
+        {
+            Console.WriteLine("[Server] Could not determine player indices for gold steal");
+            return;
+        }
+
+        int defenderGold = defenderIndex == 0 ? gameState.Player1Gold : gameState.Player2Gold;
+        int attackerGold = attackerIndex == 0 ? gameState.Player1Gold : gameState.Player2Gold;
+
+        int actualStolen = Math.Min(GoldStealAmount, defenderGold);
+
+        if (actualStolen > 0)
+        {
+            gameState.SetGold(defenderIndex, defenderGold - actualStolen);
+            gameState.SetGold(attackerIndex, attackerGold + actualStolen);
+
+            Console.WriteLine($"[Server] GreedHit stole {actualStolen} gold from Player {defenderIndex} to Player {attackerIndex}");
+
+            gameState.SyncGoldToClient(attackerIndex);
+            gameState.SyncGoldToClient(defenderIndex);
+
+            SendGoldTheftNotification(attacker, defender, actualStolen);
+        }
+        else
+        {
+            Console.WriteLine($"[Server] GreedHit could not steal gold - defender has no gold");
+        }
+    }
+
+    /// <summary>
+    /// Sends notification about gold theft to both players
+    /// </summary>
+    /// <param name="attacker">The attacking player</param>
+    /// <param name="defender">The defending player</param>
+    /// <param name="stolenAmount">The amount of gold stolen</param>
+    private static void SendGoldTheftNotification(NetPeer attacker, NetPeer defender, int stolenAmount)
+    {
+        var attackerWriter = new NetDataWriter();
+        attackerWriter.Put("GoldStolen");
+        attackerWriter.Put(stolenAmount);
+        attackerWriter.Put(true); 
+        attacker.Send(attackerWriter, DeliveryMethod.ReliableOrdered);
+
+        var defenderWriter = new NetDataWriter();
+        defenderWriter.Put("GoldStolen");
+        defenderWriter.Put(stolenAmount);
+        defenderWriter.Put(false);
+        defender.Send(defenderWriter, DeliveryMethod.ReliableOrdered);
+
+        Console.WriteLine($"[Server] Sent gold theft notifications - {stolenAmount} gold stolen");
+    }
+
+    /// <summary>
+    /// Validates if the target coordinates are valid for this card
+    /// </summary>
+    /// <param name="gameState">The current game state</param>
+    /// <param name="targetCoords">The coordinates targeted by the card</param>
+    /// <param name="defender">The defending player</param>
+    /// <returns>True if the target area is within the board, otherwise false</returns>
+    public bool IsValidTarget(GameState gameState, Vector2 targetCoords, NetPeer defender)
+    {
+        int boardWidth = GameState.boardWidth;
+        int boardHeight = GameState.boardHeight;
+
+        return targetCoords.X >= 0
+            && targetCoords.Y >= 0
+            && targetCoords.X < boardWidth
+            && targetCoords.Y < boardHeight;
+    }
+}

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -262,4 +262,21 @@ public class GameState
             Timeout.Infinite
         );
     }
+
+    /// <summary>
+    /// Gets the index of a player in the players array
+    /// </summary>
+    /// <param name="player">The player to find</param>
+    /// <returns>The index (0 or 1) or -1 if not found</returns>
+    public int GetPlayerIndex(NetPeer player)
+    {
+        for (int i = 0; i < players.Length; i++)
+        {
+            if (players[i] == player)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
 }

--- a/src/WaterWizard.Shared/Cards.cs
+++ b/src/WaterWizard.Shared/Cards.cs
@@ -131,7 +131,7 @@ public class Cards
                 Mana = 5,
                 CastTime = "2",
                 Duration = "instant",
-                Target = new("random 1x1"),
+                Target = new("1x1"),
             }
         },
         {


### PR DESCRIPTION
This pull request introduces a new damage card, `GreedHit`, to the game, along with its implementation and integration into the existing system. The `GreedHit` card has a unique mechanic that allows it to deal damage and steal gold from the opponent. Additionally, minor adjustments were made to the shared card details and game state functionality to support this new card.

### New Card Implementation:
* Added the `GreedHitCard` class in `src/WaterWizard.Server/Card/GreedHitCard.cs`. This card deals damage to a single cell and steals 2 gold from the opponent when it hits a ship. It includes methods for executing damage, handling gold theft, sending notifications, and validating targets.

### Integration with Existing Systems:
* Updated `DamageCardFactory` to include the `GreedHit` card in the card creation logic.
* Added the `GreedHit` card to the client-side card stack initialization in `InitDamage()` in `src/WaterWizard.Client/gamescreen/cards/CardStack.cs`.

### Supporting Changes:
* Introduced a `GetPlayerIndex` method in `GameState` to determine the index of a player in the players array, used for gold transfer logic.
* Modified the `Target` property of the `GreedHit` card in `src/WaterWizard.Shared/Cards.cs` to specify a "1x1" target area instead of "random 1x1".