### PR TITLE
Implement surrender mechanics: add surrender handling in client and s…

### DIFF
--- a/src/WaterWizard.Client/gamestates/InGameState.cs
+++ b/src/WaterWizard.Client/gamestates/InGameState.cs
@@ -1,4 +1,7 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
 using Raylib_cs;
+using WaterWizard.Client.network;
 
 namespace WaterWizard.Client.gamestates;
 
@@ -10,6 +13,10 @@ public class InGameState : IGameState
     /// <param name="manager">The GameStateManager instance that provides access to game components, screen dimensions, pause state, and rendering systems.</param>
     public void UpdateAndDraw(GameStateManager manager)
     {
+        if (Raylib.IsKeyPressed(KeyboardKey.S))
+        {
+            HandleSurrender();
+        }
         if (manager.GetGamePauseManager().IsGamePaused)
         {
             Raylib.DrawRectangle(
@@ -32,6 +39,31 @@ public class InGameState : IGameState
         else
         {
             DrawGameScreen(manager);
+
+            string surrenderHint = "Press 'S' to Surrender";
+            int hintWidth = Raylib.MeasureText(surrenderHint, 12);
+            Raylib.DrawText(
+                surrenderHint,
+                manager.screenWidth - hintWidth - 10,
+                10,
+                12,
+                Color.Gray);
+        }
+    }
+
+    private static void HandleSurrender()
+    {
+        var client = NetworkManager.Instance.clientService.client;
+        if (client != null && client.FirstPeer != null)
+        {
+            var writer = new NetDataWriter();
+            writer.Put("Surrender");
+            client.FirstPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            Console.WriteLine("[Client] Surrender message sent to server");
+        }
+        else
+        {
+            Console.WriteLine("[Client] Cannot surrender - not connected to server");
         }
     }
 

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -170,10 +170,10 @@ public class GameState
         Console.WriteLine("----------------------------------------\n");
 
         boards = CellHandler.InitBoards();
-        
+
         // Generiere Steine für alle Spieler-Boards
         RockHandler.GenerateAndSyncRocks(this);
-        
+
         hands =
         [
             [],
@@ -362,7 +362,7 @@ public class GameState
             writer.Put("GoldFreezeStatus");
             writer.Put(i);
             writer.Put(isFrozen);
-            
+
             peer.Send(writer, DeliveryMethod.ReliableOrdered);
             Console.WriteLine($"[GameState] GoldFreezeStatus sent to {peer} - PlayerIndex: {i}, IsFrozen: {isFrozen}");
         }
@@ -383,5 +383,16 @@ public class GameState
             }
         }
         return -1;
+    }
+    
+    /// <summary>
+    /// Handles player surrender by triggering game over with the opponent as winner
+    /// </summary>
+    /// <param name="winner">The opponent who wins due to surrender</param>
+    /// <param name="surrenderingPlayer">The player who surrendered</param>
+    public void HandleSurrender(NetPeer winner, NetPeer surrenderingPlayer)
+    {
+        Console.WriteLine($"[Server] Processing surrender - Winner: {winner}, Surrendering: {surrenderingPlayer}");
+        BroadcastGameOver(winner, surrenderingPlayer);
     }
 }

--- a/src/WaterWizard.Server/ServerGameStates/InGameState.cs
+++ b/src/WaterWizard.Server/ServerGameStates/InGameState.cs
@@ -107,13 +107,35 @@ public class InGameState(NetManager server, GameState gameState) : IServerGameSt
                 else
                     Console.WriteLine("[Server] Kein Gegner gefunden für Attack.");
                 break;
+            case "Surrender":
+                HandleSurrender(peer);
+                break;
             default:
                 Console.WriteLine($"[InGameState] Unbekannter Nachrichtentyp: {messageType}");
                 break;
         }
     }
 
-    private NetPeer? FindOpponent(NetPeer attacker)
+    /// <summary>
+    /// Handles the surrender button usage
+    /// </summary>
+    /// <param name="surrenderingPlayer">The player which surrenders</param>
+    private void HandleSurrender(NetPeer surrenderingPlayer)
+    {
+        Console.WriteLine($"[Server] Player {surrenderingPlayer} has surrendered");
+
+        var opponent = FindOpponent(surrenderingPlayer);
+        if (opponent != null)
+        {
+            gameState.HandleSurrender(opponent, surrenderingPlayer);
+        }
+        else
+        {
+            Console.WriteLine("[Server] No opponent found for surrender handling");
+        }
+    }
+
+    public NetPeer? FindOpponent(NetPeer attacker)
     {
         foreach (var peer in server.ConnectedPeerList)
         {


### PR DESCRIPTION
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJzcHByandneWNtejExdzU1d2s1ZDRvcnN5eGZyeXB5NHVta2sweiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/uVykNwkA1OTSVRuS8v/giphy.gif)

This pull request introduces a new "surrender" feature to the game, allowing players to forfeit a match. The changes include client-side logic for triggering a surrender, server-side handling of surrender messages, and updates to the game state to process the surrender event.

### Client-side changes:
* Added a keybinding for the 'S' key in `InGameState.cs` to trigger the surrender action. When pressed, the client sends a "Surrender" message to the server using the `HandleSurrender` method. (`src/WaterWizard.Client/gamestates/InGameState.cs`, [[1]](diffhunk://#diff-895e34381a34da155a6401196234eab239190ae394a9cd899707da9f8aa4c6ceR16-R19) [[2]](diffhunk://#diff-895e34381a34da155a6401196234eab239190ae394a9cd899707da9f8aa4c6ceR42-R66)
* Displayed a hint on the game screen that informs players they can press 'S' to surrender. (`src/WaterWizard.Client/gamestates/InGameState.cs`, [src/WaterWizard.Client/gamestates/InGameState.csR42-R66](diffhunk://#diff-895e34381a34da155a6401196234eab239190ae394a9cd899707da9f8aa4c6ceR42-R66))

### Server-side changes:
* Added a `HandleSurrender` method in `ServerGameStates/InGameState.cs` to process surrender messages from clients. This method identifies the opponent and delegates the surrender handling to the game state. (`src/WaterWizard.Server/ServerGameStates/InGameState.cs`, [src/WaterWizard.Server/ServerGameStates/InGameState.csR110-R138](diffhunk://#diff-a24b589e0df16ae55ee5d21b3bd5db345180de7ded125f75de02c1c432cf0bdbR110-R138))
* Updated the message-handling logic in `ServerGameStates/InGameState.cs` to recognize and handle the "Surrender" message type. (`src/WaterWizard.Server/ServerGameStates/InGameState.cs`, [src/WaterWizard.Server/ServerGameStates/InGameState.csR110-R138](diffhunk://#diff-a24b589e0df16ae55ee5d21b3bd5db345180de7ded125f75de02c1c432cf0bdbR110-R138))

### Game state updates:
* Added a `HandleSurrender` method in `GameState.cs` to finalize the surrender process. This method triggers the game-over logic, declaring the opponent as the winner. (`src/WaterWizard.Server/GameState.cs`, [src/WaterWizard.Server/GameState.csR387-R397](diffhunk://#diff-8ba47ea61bca732cdbffdb97c99ae8ad849decb67d25eb52a30ca50c516a15f9R387-R397))