### PR TITLE
Pause-Management implementiert: PauseToggle-Anfrage vom Client an den…

### DIFF
--- a/src/WaterWizard.Client/GameStateManager.cs
+++ b/src/WaterWizard.Client/GameStateManager.cs
@@ -2,6 +2,7 @@ using Raylib_cs;
 using WaterWizard.Client.gamescreen;
 using WaterWizard.Client.gamestates;
 using WaterWizard.Client.network;
+using WaterWizard.Client.gamescreen.handler;
 
 namespace WaterWizard.Client;
 
@@ -131,7 +132,7 @@ public class GameStateManager
         {
             if (currentState is InGameState)
             {
-                _gamePauseManager.TogglePause();
+                HandlePause.SendPauseToggleRequest();
             }
         }
         if (currentState is PreStartLobbyState)

--- a/src/WaterWizard.Client/gamescreen/handler/HandlePause.cs
+++ b/src/WaterWizard.Client/gamescreen/handler/HandlePause.cs
@@ -1,0 +1,25 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
+using WaterWizard.Client.network;
+
+namespace WaterWizard.Client.gamescreen.handler
+{
+    public static class HandlePause
+    {
+        public static void SendPauseToggleRequest()
+        {
+            var client = NetworkManager.Instance.clientService?.client;
+            if (client != null && client.FirstPeer != null)
+            {
+                var writer = new NetDataWriter();
+                writer.Put("PauseToggle");
+                client.FirstPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+                Console.WriteLine("[Client] PauseToggle request sent to server.");
+            }
+            else
+            {
+                Console.WriteLine("[Client] Cannot send PauseToggle request, not connected to a server.");
+            }
+        }
+    }
+} 

--- a/src/WaterWizard.Client/network/ClientService.cs
+++ b/src/WaterWizard.Client/network/ClientService.cs
@@ -147,6 +147,17 @@ public class ClientService(NetworkManager manager)
 
             switch (messageType)
             {
+                case "UpdatePauseState":
+                    bool isPaused = reader.GetBool();
+                    if (isPaused)
+                    {
+                        GameStateManager.Instance.GetGamePauseManager().PauseGame();
+                    }
+                    else
+                    {
+                        GameStateManager.Instance.GetGamePauseManager().ResumeGame();
+                    }
+                    break;
                 case "StartGame":
                     GameStateManager.Instance.SetStateToInGame();
                     break;

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -70,6 +70,8 @@ public class GameState
     public int Player1Gold { get; private set; } = 0;
     public int Player2Gold { get; private set; } = 0;
 
+    public bool IsPaused { get; set; } = false;
+
     private float _player1GoldFreezeTimer = 0f;
     private float _player2GoldFreezeTimer = 0f;
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzQzeXd4OGozaTZxeTRkdmIxaGRtbXF1cm9kN2N3bDJiNjNzOGt4NiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ai1UxGMqU7G5TZQmJa/giphy.gif)
This pull request introduces a pause functionality for the game, enabling clients to toggle the game's pause state and synchronize it with the server. The changes span both client-side and server-side implementations, including the addition of a new handler class, updates to game state management, and network communication enhancements.

### Client-side changes:

* **Pause toggle request handling**:
  - Added the `HandlePause` class in `src/WaterWizard.Client/gamescreen/handler/HandlePause.cs` to send a "PauseToggle" request to the server when toggling the pause state.
  - Updated `GameStateManager.cs` to replace `_gamePauseManager.TogglePause()` with `HandlePause.SendPauseToggleRequest()` for initiating pause toggles.

* **Pause state synchronization**:
  - Modified `ClientService.cs` to handle incoming "UpdatePauseState" messages from the server, updating the client's game pause state accordingly.

### Server-side changes:

* **Game state updates**:
  - Added an `IsPaused` property to the `GameState` class in `src/WaterWizard.Server/GameState.cs` to track whether the game is paused.

* **Pause toggle handling**:
  - Updated `InGameState.cs` to include logic for toggling the pause state upon receiving a "PauseToggle" message and broadcasting the updated state to all connected clients.
  - Added checks in `UpdateMana()` and `UpdateGold()` methods to skip updates if the game is paused.… Server gesendet und Server-Status aktualisiert. Neue Klasse HandlePause hinzugefügt, um die Pause-Logik zu verwalten. Spielzustand wird nun korrekt pausiert und fortgesetzt.