### PR TITLE
F103 shield card

### DIFF
--- a/src/WaterWizard.Client/gamescreen/CellState.cs
+++ b/src/WaterWizard.Client/gamescreen/CellState.cs
@@ -12,5 +12,6 @@ public enum CellState
     Miss,
     Unknown,
     Thunder,
-    HoveringEyeRevealed 
+    HoveringEyeRevealed,
+    Shield
 }

--- a/src/WaterWizard.Client/gamescreen/GameBoard.cs
+++ b/src/WaterWizard.Client/gamescreen/GameBoard.cs
@@ -314,6 +314,9 @@ public class GameBoard
         {
             strike.Draw(CellSize);
         }
+
+        // Shield-Effekte zeichnen
+        DrawShieldEffects();
     }
 
     /// <summary>
@@ -690,6 +693,49 @@ public class GameBoard
             
             Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, shieldColor);
             Raylib.DrawRectangleLines(cellX, cellY, CellSize, CellSize, new Color(0, 200, 200, (int)(255 * alpha)));
+        }
+    }
+
+    /// <summary>
+    /// Draws shield effects on the game board
+    /// </summary>
+    private void DrawShieldEffects()
+    {
+        foreach (var kvp in _shieldedCells)
+        {
+            var (x, y) = kvp.Key;
+            float duration = kvp.Value;
+            
+            int posX = (int)Position.X + x * CellSize;
+            int posY = (int)Position.Y + y * CellSize;
+            
+            float alpha = Math.Min(1.0f, duration / 6.0f); 
+            int alphaValue = (int)(alpha * 150);
+            
+            Color shieldColor = new(0, 255, 255, alphaValue);
+            Raylib.DrawRectangle(posX, posY, CellSize, CellSize, shieldColor);
+            
+            Color borderColor = new(0, 200, 200, Math.Min(255, alphaValue + 100));
+            Raylib.DrawRectangleLines(posX, posY, CellSize, CellSize, borderColor);
+            
+            int centerX = posX + CellSize / 2;
+            int centerY = posY + CellSize / 2;
+            int symbolSize = CellSize / 4;
+            
+            Vector2[] points = new Vector2[]
+            {
+                new(centerX, centerY - symbolSize),   
+                new(centerX + symbolSize, centerY),   
+                new(centerX, centerY + symbolSize),    
+                new(centerX - symbolSize, centerY)   
+            };
+            
+            Color symbolColor = new(255, 255, 255, Math.Min(255, alphaValue + 100));
+            for (int i = 0; i < points.Length; i++)
+            {
+                int next = (i + 1) % points.Length;
+                Raylib.DrawLineEx(points[i], points[next], 2f, symbolColor);
+            }
         }
     }
 }

--- a/src/WaterWizard.Client/gamescreen/cards/CardStack.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/CardStack.cs
@@ -32,6 +32,7 @@ public class CardStack(GameScreen gameScreen, int x, int y)
     {
         //later calls to Network to get correct Cards
         cards.Add(new(gameScreen, new(Shared.CardVariant.Heal)));
+        cards.Add(new(gameScreen, new(Shared.CardVariant.Shield)));
     }
 
     public void Draw()

--- a/src/WaterWizard.Client/gamescreen/cards/CardStack.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/CardStack.cs
@@ -20,6 +20,7 @@ public class CardStack(GameScreen gameScreen, int x, int y)
     {
         //later calls to Network to get correct Cards
         cards.Add(new(gameScreen, new(Shared.CardVariant.Paralize)));
+        cards.Add(new(gameScreen, new(Shared.CardVariant.Shield)));
     }
 
     public void InitEnvironment()
@@ -32,7 +33,6 @@ public class CardStack(GameScreen gameScreen, int x, int y)
     {
         //later calls to Network to get correct Cards
         cards.Add(new(gameScreen, new(Shared.CardVariant.Heal)));
-        cards.Add(new(gameScreen, new(Shared.CardVariant.Shield)));
     }
 
     public void Draw()

--- a/src/WaterWizard.Client/gamescreen/cards/CastingUI.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/CastingUI.cs
@@ -176,10 +176,8 @@ public class CastingUI
 
         if (hoveredCoords.HasValue)
         {
-            var onScreenX =
-                boardPos.X + (hoveredCoords.Value.X - (float)Math.Floor(aim.X / 2f)) * CellSize;
-            var onScreenY =
-                boardPos.Y + (hoveredCoords.Value.Y - (float)Math.Floor(aim.Y / 2f)) * CellSize;
+            var onScreenX = boardPos.X + (hoveredCoords.Value.X - (float)Math.Floor(aim.X / 2f)) * CellSize;
+            var onScreenY = boardPos.Y + (hoveredCoords.Value.Y - (float)Math.Floor(aim.Y / 2f)) * CellSize;
             var r = new Rectangle(onScreenX, onScreenY, aim.X * CellSize, aim.Y * CellSize);
             Raylib.DrawRectangleLinesEx(r, 2, Color.Red);
 

--- a/src/WaterWizard.Client/gamescreen/handler/HandleShield.cs
+++ b/src/WaterWizard.Client/gamescreen/handler/HandleShield.cs
@@ -1,0 +1,89 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
+
+namespace WaterWizard.Client.gamescreen.handler;
+
+/// <summary>
+/// Handles shield-related messages received from the server.
+/// </summary>
+public static class HandleShield
+{
+    /// <summary>
+    /// Handles the shield created message received from the server.
+    /// </summary>
+    /// <param name="reader">The NetPacketReader containing the shield data</param>
+    public static void HandleShieldCreated(NetPacketReader reader)
+    {
+        int playerIndex = reader.GetInt();
+        int x = reader.GetInt();
+        int y = reader.GetInt();
+        float duration = reader.GetFloat();
+
+        var gameScreen = GameStateManager.Instance.GameScreen;
+        if (gameScreen != null)
+        {
+            int myPlayerIndex = GameStateManager.Instance.MyPlayerIndex;
+            
+            // Determine which board to apply the shield visual to
+            GameBoard? targetBoard = null;
+            if (playerIndex == myPlayerIndex)
+            {
+                // Shield on my own board
+                targetBoard = gameScreen.playerBoard;
+                Console.WriteLine($"[Client] Shield created on MY board at ({x}, {y}) for {duration} seconds");
+            }
+            else
+            {
+                // Shield on opponent's board (visible to me)
+                targetBoard = gameScreen.opponentBoard;
+                Console.WriteLine($"[Client] Shield created on OPPONENT's board at ({x}, {y}) for {duration} seconds");
+            }
+
+            if (targetBoard != null)
+            {
+                targetBoard.AddShieldEffect(x, y, duration);
+            }
+        }
+        
+        Console.WriteLine($"[Client] Shield created: Player {playerIndex + 1} at ({x}, {y}) duration: {duration}s");
+    }
+
+    /// <summary>
+    /// Handles the shield expired message received from the server.
+    /// </summary>
+    /// <param name="reader">The NetPacketReader containing the shield expiration data</param>
+    public static void HandleShieldExpired(NetPacketReader reader)
+    {
+        int playerIndex = reader.GetInt();
+        int x = reader.GetInt();
+        int y = reader.GetInt();
+
+        var gameScreen = GameStateManager.Instance.GameScreen;
+        if (gameScreen != null)
+        {
+            int myPlayerIndex = GameStateManager.Instance.MyPlayerIndex;
+            
+            // Determine which board to remove the shield visual from
+            GameBoard? targetBoard = null;
+            if (playerIndex == myPlayerIndex)
+            {
+                // Shield on my own board
+                targetBoard = gameScreen.playerBoard;
+                Console.WriteLine($"[Client] Shield expired on MY board at ({x}, {y})");
+            }
+            else
+            {
+                // Shield on opponent's board (visible to me)
+                targetBoard = gameScreen.opponentBoard;
+                Console.WriteLine($"[Client] Shield expired on OPPONENT's board at ({x}, {y})");
+            }
+
+            if (targetBoard != null)
+            {
+                targetBoard.RemoveShieldEffect(x, y);
+            }
+        }
+        
+        Console.WriteLine($"[Client] Shield expired: Player {playerIndex + 1} at ({x}, {y})");
+    }
+}

--- a/src/WaterWizard.Client/network/ClientService.cs
+++ b/src/WaterWizard.Client/network/ClientService.cs
@@ -411,6 +411,12 @@ public class ClientService(NetworkManager manager)
                 case "HoveringEyeReveal":
                     HandleUtility.HandleHoveringEyeReveal(reader);
                     break;
+                case "ShieldCreated":
+                    HandleShield.HandleShieldCreated(reader);
+                    break;
+                case "ShieldExpired":
+                    HandleShield.HandleShieldExpired(reader);
+                    break;
             }
         }
         catch (Exception ex)

--- a/src/WaterWizard.Server/Card/damage/ArcaneMissileCard.cs
+++ b/src/WaterWizard.Server/Card/damage/ArcaneMissileCard.cs
@@ -67,6 +67,17 @@ public class ArcaneMissileCard : IDamageCard
 
             Console.WriteLine($"[Server] Arcane Missile #{missile + 1} targeting ({x}, {y})");
 
+            // Get defender's player index for shield check
+            int defenderIndex = gameState.GetPlayerIndex(defender);
+
+            // Check if this coordinate is protected by a shield
+            if (defenderIndex != -1 && gameState.IsCoordinateProtectedByShield(x, y, defenderIndex))
+            {
+                Console.WriteLine($"[Server] Arcane Missile #{missile + 1} at ({x}, {y}) blocked by shield!");
+                CellHandler.SendCellReveal(attacker, defender, x, y, false);
+                continue;
+            }
+
             foreach (var ship in ships)
             {
                 if (x >= ship.X && x < ship.X + ship.Width &&

--- a/src/WaterWizard.Server/Card/damage/FireboltCard.cs
+++ b/src/WaterWizard.Server/Card/damage/FireboltCard.cs
@@ -52,6 +52,9 @@ public class FireboltCard : IDamageCard
         var ships = ShipHandler.GetShips(defender);
         bool anyHit = false;
 
+        // Get defender's player index for shield check
+        int defenderIndex = gameState.GetPlayerIndex(defender);
+
         for (int dx = 0; dx < (int)AreaOfEffect.X; dx++)
         {
             for (int dy = 0; dy < (int)AreaOfEffect.Y; dy++)
@@ -59,6 +62,14 @@ public class FireboltCard : IDamageCard
                 int x = startX + dx;
                 int y = startY + dy;
                 bool cellHit = false;
+
+                // Check if this coordinate is protected by a shield
+                if (defenderIndex != -1 && gameState.IsCoordinateProtectedByShield(x, y, defenderIndex))
+                {
+                    Console.WriteLine($"[Server] Firebolt attack at ({x}, {y}) blocked by shield!");
+                    CellHandler.SendCellReveal(attacker, defender, x, y, false);
+                    continue;
+                }
 
                 foreach (var ship in ships)
                 {

--- a/src/WaterWizard.Server/Card/damage/FrostBoltCard.cs
+++ b/src/WaterWizard.Server/Card/damage/FrostBoltCard.cs
@@ -56,6 +56,17 @@ public class FrostBoltCard : IDamageCard
         int x = (int)targetCoords.X;
         int y = (int)targetCoords.Y;
 
+        // Get defender's player index for shield check
+        int defenderIndex = gameState.GetPlayerIndex(defender);
+
+        // Check if this coordinate is protected by a shield
+        if (defenderIndex != -1 && gameState.IsCoordinateProtectedByShield(x, y, defenderIndex))
+        {
+            Console.WriteLine($"[Server] FrostBolt attack at ({x}, {y}) blocked by shield!");
+            CellHandler.SendCellReveal(attacker, defender, x, y, false);
+            return false;
+        }
+
         var ships = ShipHandler.GetShips(defender);
         bool hit = false;
 

--- a/src/WaterWizard.Server/Card/damage/GreedHitCard.cs
+++ b/src/WaterWizard.Server/Card/damage/GreedHitCard.cs
@@ -56,6 +56,17 @@ public class GreedHitCard : IDamageCard
         int x = (int)targetCoords.X;
         int y = (int)targetCoords.Y;
 
+        // Get defender's player index for shield check
+        int defenderIndex = gameState.GetPlayerIndex(defender);
+
+        // Check if this coordinate is protected by a shield
+        if (defenderIndex != -1 && gameState.IsCoordinateProtectedByShield(x, y, defenderIndex))
+        {
+            Console.WriteLine($"[Server] GreedHit attack at ({x}, {y}) blocked by shield!");
+            CellHandler.SendCellReveal(attacker, defender, x, y, false);
+            return false;
+        }
+
         var ships = ShipHandler.GetShips(defender);
         bool hit = false;
 

--- a/src/WaterWizard.Server/Card/environment/ThunderCard.cs
+++ b/src/WaterWizard.Server/Card/environment/ThunderCard.cs
@@ -90,6 +90,17 @@ public class ThunderCard : IEnvironmentCard
     /// </summary>
     private static bool HandleThunderStrike(GameState gameState, NetPeer attacker, NetPeer targetPlayer, int x, int y)
     {
+        // Get target player's index for shield check
+        int targetPlayerIndex = gameState.GetPlayerIndex(targetPlayer);
+
+        // Check if this coordinate is protected by a shield
+        if (targetPlayerIndex != -1 && gameState.IsCoordinateProtectedByShield(x, y, targetPlayerIndex))
+        {
+            Console.WriteLine($"    Thunder strike at ({x}, {y}) blocked by shield!");
+            CellHandler.SendCellReveal(attacker, targetPlayer, x, y, false);
+            return false;
+        }
+
         var ships = ShipHandler.GetShips(targetPlayer);
         bool hit = false;
 

--- a/src/WaterWizard.Server/Card/healing/HealingCardFactory.cs
+++ b/src/WaterWizard.Server/Card/healing/HealingCardFactory.cs
@@ -15,7 +15,6 @@ public class HealingCardFactory
         return variant switch
         {
             CardVariant.Heal => new HealCard(),
-            CardVariant.Shield => new ShieldCard(),
             _ => null,
         };
     }

--- a/src/WaterWizard.Server/Card/healing/HealingCardFactory.cs
+++ b/src/WaterWizard.Server/Card/healing/HealingCardFactory.cs
@@ -15,6 +15,7 @@ public class HealingCardFactory
         return variant switch
         {
             CardVariant.Heal => new HealCard(),
+            CardVariant.Shield => new ShieldCard(),
             _ => null,
         };
     }

--- a/src/WaterWizard.Server/Card/healing/ShieldCard.cs
+++ b/src/WaterWizard.Server/Card/healing/ShieldCard.cs
@@ -1,0 +1,114 @@
+using System.Numerics;
+using LiteNetLib;
+using LiteNetLib.Utils;
+using WaterWizard.Server.handler;
+using WaterWizard.Server.Interface;
+using WaterWizard.Shared;
+
+namespace WaterWizard.Server.Card.healing;
+
+/// <summary>
+/// Implementation of the Shield healing card
+/// Creates a protective 3x3 area that prevents damage for 6 seconds
+/// </summary>
+public class ShieldCard : IHealingCard
+{
+    public CardVariant Variant => CardVariant.Shield;
+
+    public Vector2 AreaOfEffect => new(3, 3);
+
+    public int BaseHealing => 0; // Shield doesn't heal, it protects
+
+    public bool HasSpecialTargeting => false;
+
+    public bool ExecuteHealing(GameState gameState, Vector2 targetCoords, NetPeer caster, NetPeer opponent)
+    {
+        int startX = (int)targetCoords.X;
+        int startY = (int)targetCoords.Y;
+
+        // Find the player index of the caster
+        int casterIndex = -1;
+        for (int i = 0; i < gameState.players.Length; i++)
+        {
+            if (gameState.players[i]?.Equals(caster) == true)
+            {
+                casterIndex = i;
+                break;
+            }
+        }
+
+        if (casterIndex == -1)
+        {
+            Console.WriteLine("[ShieldCard] Could not find caster index for Shield");
+            return false;
+        }
+
+        // Create shield effect
+        var shieldEffect = new ShieldEffect(targetCoords, casterIndex, 6.0f);
+        
+        // Add shield to game state (we'll need to add this to GameState)
+        gameState.AddShieldEffect(shieldEffect);
+
+        Console.WriteLine($"[ShieldCard] Shield created at ({startX}, {startY}) for player {casterIndex + 1}, duration: 6 seconds");
+
+        // Send shield creation message to both players
+        SendShieldCreated(gameState.players, casterIndex, startX, startY, 6.0f);
+
+        return true;
+    }
+
+    public bool IsValidTarget(GameState gameState, Vector2 targetCoords, NetPeer caster, NetPeer opponent)
+    {
+        int boardWidth = GameState.boardWidth;
+        int boardHeight = GameState.boardHeight;
+
+        // Check if the 3x3 area fits within the board
+        return targetCoords.X >= 0
+            && targetCoords.Y >= 0
+            && targetCoords.X + AreaOfEffect.X <= boardWidth
+            && targetCoords.Y + AreaOfEffect.Y <= boardHeight;
+    }
+
+    /// <summary>
+    /// Sends shield creation notification to all players
+    /// </summary>
+    private static void SendShieldCreated(NetPeer[] players, int casterIndex, int x, int y, float duration)
+    {
+        foreach (var player in players)
+        {
+            if (player != null)
+            {
+                var writer = new NetDataWriter();
+                writer.Put("ShieldCreated");
+                writer.Put(casterIndex);
+                writer.Put(x);
+                writer.Put(y);
+                writer.Put(duration);
+                player.Send(writer, DeliveryMethod.ReliableOrdered);
+            }
+        }
+
+        Console.WriteLine($"[ShieldCard] Shield creation notification sent to all players: ({x},{y}) duration: {duration}s");
+    }
+
+    /// <summary>
+    /// Sends shield expiration notification to all players
+    /// </summary>
+    public static void SendShieldExpired(NetPeer[] players, int playerIndex, int x, int y)
+    {
+        foreach (var player in players)
+        {
+            if (player != null)
+            {
+                var writer = new NetDataWriter();
+                writer.Put("ShieldExpired");
+                writer.Put(playerIndex);
+                writer.Put(x);
+                writer.Put(y);
+                player.Send(writer, DeliveryMethod.ReliableOrdered);
+            }
+        }
+
+        Console.WriteLine($"[ShieldCard] Shield expiration notification sent to all players: ({x},{y})");
+    }
+}

--- a/src/WaterWizard.Server/Card/utility/ShieldCard.cs
+++ b/src/WaterWizard.Server/Card/utility/ShieldCard.cs
@@ -5,28 +5,25 @@ using WaterWizard.Server.handler;
 using WaterWizard.Server.Interface;
 using WaterWizard.Shared;
 
-namespace WaterWizard.Server.Card.healing;
+namespace WaterWizard.Server.Card.utility;
 
 /// <summary>
-/// Implementation of the Shield healing card
+/// Implementation of the Shield utility card
 /// Creates a protective 3x3 area that prevents damage for 6 seconds
 /// </summary>
-public class ShieldCard : IHealingCard
+public class ShieldCard : IUtilityCard
 {
     public CardVariant Variant => CardVariant.Shield;
 
     public Vector2 AreaOfEffect => new(3, 3);
 
-    public int BaseHealing => 0; // Shield doesn't heal, it protects
-
     public bool HasSpecialTargeting => false;
 
-    public bool ExecuteHealing(GameState gameState, Vector2 targetCoords, NetPeer caster, NetPeer opponent)
+    public bool ExecuteUtility(GameState gameState, Vector2 targetCoords, NetPeer caster, NetPeer opponent)
     {
         int startX = (int)targetCoords.X;
         int startY = (int)targetCoords.Y;
 
-        // Find the player index of the caster
         int casterIndex = -1;
         for (int i = 0; i < gameState.players.Length; i++)
         {
@@ -43,15 +40,12 @@ public class ShieldCard : IHealingCard
             return false;
         }
 
-        // Create shield effect
         var shieldEffect = new ShieldEffect(targetCoords, casterIndex, 6.0f);
         
-        // Add shield to game state (we'll need to add this to GameState)
         gameState.AddShieldEffect(shieldEffect);
 
         Console.WriteLine($"[ShieldCard] Shield created at ({startX}, {startY}) for player {casterIndex + 1}, duration: 6 seconds");
 
-        // Send shield creation message to both players
         SendShieldCreated(gameState.players, casterIndex, startX, startY, 6.0f);
 
         return true;
@@ -62,7 +56,6 @@ public class ShieldCard : IHealingCard
         int boardWidth = GameState.boardWidth;
         int boardHeight = GameState.boardHeight;
 
-        // Check if the 3x3 area fits within the board
         return targetCoords.X >= 0
             && targetCoords.Y >= 0
             && targetCoords.X + AreaOfEffect.X <= boardWidth
@@ -87,8 +80,6 @@ public class ShieldCard : IHealingCard
                 player.Send(writer, DeliveryMethod.ReliableOrdered);
             }
         }
-
-        Console.WriteLine($"[ShieldCard] Shield creation notification sent to all players: ({x},{y}) duration: {duration}s");
     }
 
     /// <summary>
@@ -108,7 +99,5 @@ public class ShieldCard : IHealingCard
                 player.Send(writer, DeliveryMethod.ReliableOrdered);
             }
         }
-
-        Console.WriteLine($"[ShieldCard] Shield expiration notification sent to all players: ({x},{y})");
     }
 }

--- a/src/WaterWizard.Server/Card/utility/UtilityCardFactory.cs
+++ b/src/WaterWizard.Server/Card/utility/UtilityCardFactory.cs
@@ -16,6 +16,7 @@ public class UtilityCardFactory
         {
             CardVariant.Paralize => new ParalizeCard(),
             CardVariant.HoveringEye => new HoveringEyeCard(),
+            CardVariant.Shield => new ShieldCard(),
             _ => null,
         };
     }

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -421,8 +421,7 @@ public class GameState
 
             if (!shield.IsActive)
             {
-                // Notify clients that shield expired
-                Card.healing.ShieldCard.SendShieldExpired(players, shield.PlayerIndex, (int)shield.Position.X, (int)shield.Position.Y);
+                Card.utility.ShieldCard.SendShieldExpired(players, shield.PlayerIndex, (int)shield.Position.X, (int)shield.Position.Y);
                 _activeShields.RemoveAt(i);
                 Console.WriteLine($"[GameState] Shield expired and removed at ({shield.Position.X}, {shield.Position.Y}) for player {shield.PlayerIndex + 1}");
             }

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -78,6 +78,10 @@ public class GameState
     public bool IsPlayer1GoldFrozen => _player1GoldFreezeTimer > 0f;
     public bool IsPlayer2GoldFrozen => _player2GoldFreezeTimer > 0f;
 
+    // Shield management
+    private readonly List<ShieldEffect> _activeShields = new();
+    public IReadOnlyList<ShieldEffect> ActiveShields => _activeShields.AsReadOnly();
+
     /// <summary>
     /// Öffentlicher Zugriff auf den Server für Handler-Klassen
     /// </summary>
@@ -392,5 +396,51 @@ public class GameState
     {
         Console.WriteLine($"[Server] Processing surrender - Winner: {winner}, Surrendering: {surrenderingPlayer}");
         BroadcastGameOver(winner, surrenderingPlayer);
+    }
+
+    /// <summary>
+    /// Adds a new shield effect to the game state
+    /// </summary>
+    /// <param name="shieldEffect">The shield effect to add</param>
+    public void AddShieldEffect(ShieldEffect shieldEffect)
+    {
+        _activeShields.Add(shieldEffect);
+        Console.WriteLine($"[GameState] Shield added at ({shieldEffect.Position.X}, {shieldEffect.Position.Y}) for player {shieldEffect.PlayerIndex + 1}");
+    }
+
+    /// <summary>
+    /// Updates all active shield effects and removes expired ones
+    /// </summary>
+    /// <param name="deltaTime">Time elapsed since last update in seconds</param>
+    public void UpdateShields(float deltaTime)
+    {
+        for (int i = _activeShields.Count - 1; i >= 0; i--)
+        {
+            var shield = _activeShields[i];
+            shield.Update(deltaTime);
+
+            if (!shield.IsActive)
+            {
+                // Notify clients that shield expired
+                Card.healing.ShieldCard.SendShieldExpired(players, shield.PlayerIndex, (int)shield.Position.X, (int)shield.Position.Y);
+                _activeShields.RemoveAt(i);
+                Console.WriteLine($"[GameState] Shield expired and removed at ({shield.Position.X}, {shield.Position.Y}) for player {shield.PlayerIndex + 1}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if a coordinate is protected by any active shield
+    /// </summary>
+    /// <param name="x">X coordinate</param>
+    /// <param name="y">Y coordinate</param>
+    /// <param name="playerIndex">The player index to check shields for</param>
+    /// <returns>True if the coordinate is protected by a shield</returns>
+    public bool IsCoordinateProtectedByShield(int x, int y, int playerIndex)
+    {
+        return _activeShields.Any(shield => 
+            shield.IsActive && 
+            shield.PlayerIndex == playerIndex && 
+            shield.IsCoordinateProtected(x, y));
     }
 }

--- a/src/WaterWizard.Server/ServerGameStates/InGameState.cs
+++ b/src/WaterWizard.Server/ServerGameStates/InGameState.cs
@@ -15,6 +15,7 @@ public class InGameState(NetManager server, GameState gameState) : IServerGameSt
 
     private System.Timers.Timer? manaTimer;
     private System.Timers.Timer? goldTimer;
+    private System.Timers.Timer? shieldTimer;
     private ManaHandler? manaHandler;
     public ParalizeHandler? paralizeHandler;
     private GoldHandler? goldHandler;
@@ -47,6 +48,12 @@ public class InGameState(NetManager server, GameState gameState) : IServerGameSt
         goldTimer.Elapsed += (sender, e) => UpdateGold();
         goldTimer.AutoReset = true;
         goldTimer.Start();
+
+        // Shield timer - updates every 100ms for precise shield expiration
+        shieldTimer = new System.Timers.Timer(100);
+        shieldTimer.Elapsed += (sender, e) => UpdateShields();
+        shieldTimer.AutoReset = true;
+        shieldTimer.Start();
     }
 
     private void UpdateMana()
@@ -61,6 +68,13 @@ public class InGameState(NetManager server, GameState gameState) : IServerGameSt
         goldHandler?.UpdateGold();
     }
 
+    private void UpdateShields()
+    {
+        if (gameState.IsPaused) return;
+        // Update shields with delta time of 0.1 seconds (100ms timer interval)
+        gameState.UpdateShields(0.1f);
+    }
+
     /// <summary>
     /// Wird beim Verlassen des States aufgerufen (hier leer).
     /// </summary>
@@ -71,6 +85,9 @@ public class InGameState(NetManager server, GameState gameState) : IServerGameSt
         
         goldTimer?.Stop();
         goldTimer?.Dispose();
+        
+        shieldTimer?.Stop();
+        shieldTimer?.Dispose();
     }
 
     public void HandleNetworkEvent(

--- a/src/WaterWizard.Server/handler/AttackHandler.cs
+++ b/src/WaterWizard.Server/handler/AttackHandler.cs
@@ -27,6 +27,18 @@ public class AttackHandler
             $"[Server] HandleAttack called: attacker={attacker}, defender={defender}, coords=({x},{y})"
         );
 
+        // Get defender's player index for shield check
+        int defenderIndex = gameState?.GetPlayerIndex(defender) ?? -1;
+
+        // Check if this coordinate is protected by a shield
+        if (defenderIndex != -1 && gameState != null && gameState.IsCoordinateProtectedByShield(x, y, defenderIndex))
+        {
+            Console.WriteLine($"[Server] Attack at ({x}, {y}) blocked by shield!");
+            CellHandler.SendCellReveal(attacker, defender, x, y, false);
+            SendAttackResult(attacker, defender, x, y, false, false);
+            return;
+        }
+
         var ships = ShipHandler.GetShips(defender);
         bool hit = false;
         PlacedShip? hitShip = null;

--- a/src/WaterWizard.Server/handler/ShipHandler.cs
+++ b/src/WaterWizard.Server/handler/ShipHandler.cs
@@ -179,7 +179,6 @@ public class ShipHandler
         writer.Put(ship.Y);
         writer.Put(ship.Width);
         writer.Put(ship.Height);
-        writer.Put(false);
 
         writer.Put(ship.DamagedCells.Count);
         foreach (var (damageX, damageY) in ship.DamagedCells)

--- a/src/WaterWizard.Shared/CardVariant.cs
+++ b/src/WaterWizard.Shared/CardVariant.cs
@@ -18,6 +18,7 @@ public enum CardVariant
     ConeOfCold,
     MinorIllusion,
     Polymorph,
+    Shield,
 
     // Environment Variants
     Thunder,
@@ -32,5 +33,4 @@ public enum CardVariant
     MassMending,
     PerfectMending,
     Lifesteal,
-    Shield,
 }

--- a/src/WaterWizard.Shared/CardVariant.cs
+++ b/src/WaterWizard.Shared/CardVariant.cs
@@ -32,4 +32,5 @@ public enum CardVariant
     MassMending,
     PerfectMending,
     Lifesteal,
+    Shield,
 }

--- a/src/WaterWizard.Shared/Cards.cs
+++ b/src/WaterWizard.Shared/Cards.cs
@@ -325,7 +325,7 @@ public class Cards
                 Mana = 5,
                 CastTime = "instant",
                 Duration = "6",
-                Target = new(true, "3x3"),  // Set Ally = true to target player's own board
+                Target = new(true, "3x3"),
             }
         },
     };

--- a/src/WaterWizard.Shared/Cards.cs
+++ b/src/WaterWizard.Shared/Cards.cs
@@ -64,6 +64,7 @@ public class Cards
         { CardVariant.ConeOfCold, CardType.Utility },
         { CardVariant.MinorIllusion, CardType.Utility },
         { CardVariant.Polymorph, CardType.Utility },
+        { CardVariant.Shield, CardType.Utility },
         // Environment Variants
         { CardVariant.Thunder, CardType.Environment },
         { CardVariant.Storm, CardType.Environment },
@@ -76,7 +77,6 @@ public class Cards
         { CardVariant.MassMending, CardType.Healing },
         { CardVariant.PerfectMending, CardType.Healing },
         { CardVariant.Lifesteal, CardType.Healing },
-        { CardVariant.Shield, CardType.Healing },
     };
 
     private static readonly Dictionary<CardVariant, CardStats> cardStatsMapping = new Dictionary<

--- a/src/WaterWizard.Shared/Cards.cs
+++ b/src/WaterWizard.Shared/Cards.cs
@@ -76,6 +76,7 @@ public class Cards
         { CardVariant.MassMending, CardType.Healing },
         { CardVariant.PerfectMending, CardType.Healing },
         { CardVariant.Lifesteal, CardType.Healing },
+        { CardVariant.Shield, CardType.Healing },
     };
 
     private static readonly Dictionary<CardVariant, CardStats> cardStatsMapping = new Dictionary<
@@ -315,6 +316,16 @@ public class Cards
                 CastTime = "instant",
                 Duration = "instant",
                 Target = new(true, "ship"),
+            }
+        },
+        {
+            CardVariant.Shield,
+            new CardStats
+            {
+                Mana = 5,
+                CastTime = "instant",
+                Duration = "6",
+                Target = new(true, "3x3"),  // Set Ally = true to target player's own board
             }
         },
     };

--- a/src/WaterWizard.Shared/CellState.cs
+++ b/src/WaterWizard.Shared/CellState.cs
@@ -9,6 +9,7 @@ public enum CellState
     Miss,
     Unknown,
     Thunder,
-    HoveringEyeRevealed 
+    HoveringEyeRevealed,
+    Shield
 
 }

--- a/src/WaterWizard.Shared/ShieldEffect.cs
+++ b/src/WaterWizard.Shared/ShieldEffect.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Numerics;
+
+namespace WaterWizard.Shared;
+
+public class ShieldEffect
+{
+    public Vector2 Position { get; }
+    public int PlayerIndex { get; }
+    public float RemainingDuration { get; private set; }
+    public bool IsActive => RemainingDuration > 0;
+
+    public ShieldEffect(Vector2 position, int playerIndex, float duration)
+    {
+        Position = position;
+        PlayerIndex = playerIndex;
+        RemainingDuration = duration;
+    }
+
+    public void Update(float deltaTime)
+    {
+        if (RemainingDuration > 0)
+        {
+            RemainingDuration -= deltaTime;
+            if (RemainingDuration <= 0)
+            {
+                RemainingDuration = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if the given coordinates are protected by this shield
+    /// </summary>
+    /// <param name="x">X coordinate to check</param>
+    /// <param name="y">Y coordinate to check</param>
+    /// <returns>True if the coordinates are within the shield's 3x3 area</returns>
+    public bool IsCoordinateProtected(int x, int y)
+    {
+        if (!IsActive) return false;
+
+        return x >= Position.X && x < Position.X + 3 &&
+               y >= Position.Y && y < Position.Y + 3;
+    }
+}

--- a/src/WaterWizard.Shared/ShieldEffect.cs
+++ b/src/WaterWizard.Shared/ShieldEffect.cs
@@ -39,7 +39,10 @@ public class ShieldEffect
     {
         if (!IsActive) return false;
 
-        return x >= Position.X && x < Position.X + 3 &&
-               y >= Position.Y && y < Position.Y + 3;
+        bool isProtected = x >= Position.X - 1 && x <= Position.X + 1 &&
+                          y >= Position.Y - 1 && y <= Position.Y + 1;
+                          
+        Console.WriteLine($"[ShieldEffect] Checking protection at ({x}, {y}) vs center ({Position.X}, {Position.Y}): {(isProtected ? "PROTECTED" : "NOT PROTECTED")}");
+        return isProtected;
     }
 }


### PR DESCRIPTION
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMnNnZmt2eG5ub2VvN3FzbzJ1dGR5OWtmaHVyeHhiampyNWJhMHppNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/45QMTpsR3FmQqRcfcN/giphy.gif)

This pull request introduces a new "Shield" mechanic to the game, adding functionality for protective areas that block damage for a limited duration. The changes span client-side visual updates, server-side logic for shield creation and expiration, and integration with existing cards and game mechanics.

### Shield Mechanic Implementation:

* **Client-side Shield Effects**:
  - Added `Shield` to the `CellState` enum and updated `GetColorForState` to assign a cyan color with transparency for shield cells. (`src/WaterWizard.Client/gamescreen/CellState.cs`, [[1]](diffhunk://#diff-0a0293e5e1b7724cbeb385f4b1eb2e68f0c53fb0665ed3f9fbddb9cc7edf39d2L15-R16); `src/WaterWizard.Client/gamescreen/GameBoard.cs`, [[2]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aR338)
  - Implemented shield effect tracking, drawing logic, and visual updates, including fading transparency as the shield duration decreases. (`src/WaterWizard.Client/gamescreen/GameBoard.cs`, [[1]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aR30-R53) [[2]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aR317-R319) [[3]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aL544-R670) [[4]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aR686-R739)
  - Added shield-related cards to the utility card stack. (`src/WaterWizard.Client/gamescreen/cards/CardStack.cs`, [src/WaterWizard.Client/gamescreen/cards/CardStack.csR23](diffhunk://#diff-cb130703f987afd8a5e0b2210d897a1688558b2a4c96fb0c81e766afa2fca4d6R23))

* **Server-side Shield Logic**:
  - Introduced `ShieldCard`, which creates a protective 3x3 area for 6 seconds, preventing damage to cells within its radius. (`src/WaterWizard.Server/Card/utility/ShieldCard.cs`, [src/WaterWizard.Server/Card/utility/ShieldCard.csR1-R103](diffhunk://#diff-17793d59a0a9ff3e602aac356534fd83ee89fbd1e2b10eb72498216ea89ae52bR1-R103))
  - Updated damage cards (`ArcaneMissileCard`, `FireboltCard`, `FrostBoltCard`, `GreedHitCard`, and `ThunderCard`) to check for shield protection before applying damage. (`src/WaterWizard.Server/Card/damage`, [[1]](diffhunk://#diff-64ed533140180ea83e2ee1a21487b0110b6953269c43273a51550217217bde22R70-R80) [[2]](diffhunk://#diff-9e954a475c818e10ebdbd7477bb13f5a59700769edd6901b67680569fa1e71feR55-R57) [[3]](diffhunk://#diff-9e954a475c818e10ebdbd7477bb13f5a59700769edd6901b67680569fa1e71feR66-R73) [[4]](diffhunk://#diff-152c8b5159ffb7810e6ca67ed61bfd4808ebd0dc075dcef6e3912e5c09a13239R59-R69) [[5]](diffhunk://#diff-27b5c9d8015d89e270ce02724c20b9ff5d7ca20b7a23b3affa9e35af1f3f51faR59-R69) [[6]](diffhunk://#diff-4fbd57d1085356915dcf4d943ae294d5a5a8a13ec1d48736329cb6d147a6109eR93-R103)

### Network Integration:

* **Shield Message Handling**:
  - Added client-side handlers for shield creation and expiration messages received from the server. (`src/WaterWizard.Client/gamescreen/handler/HandleShield.cs`, [src/WaterWizard.Client/gamescreen/handler/HandleShield.csR1-R89](diffhunk://#diff-9cae8e4d84cc72c48950349af1561996118d97ea63b45e816ddd91ef93b1cf63R1-R89))
  - Integrated shield-related message handling into the client network service. (`src/WaterWizard.Client/network/ClientService.cs`, [src/WaterWizard.Client/network/ClientService.csR414-R419](diffhunk://#diff-d8e0da846b4e1b62c8876bf41fb5522dda85a091d94b81c4743d8adae8e22d4eR414-R419))

These changes enhance the game's strategic depth by introducing a defensive mechanic that players can deploy tactically to protect their boards.