### PR TITLE
Implement card removal from player's hand after casting and add serve…

### DIFF
--- a/src/WaterWizard.Client/gamescreen/cards/CastingUI.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/CastingUI.cs
@@ -27,6 +27,8 @@ public class CastingUI
     private int selectedShipIndex = -1;
     private Vector2 selectedShipCoords = new();
 
+    public GameHand? PlayerHand { get; private set; }
+
     public void Draw()
     {
         if (aiming)
@@ -47,6 +49,7 @@ public class CastingUI
         {
             aiming = false;
             NetworkManager.HandleCast(gameCard.card, new Point(0, 0));
+            RemoveCardFromHand(gameCard.card); 
             return;
         }
 
@@ -78,6 +81,7 @@ public class CastingUI
             {
                 aiming = false;
                 NetworkManager.HandleCast(cardToAim!.card, new Point(0, 0));
+                RemoveCardFromHand(cardToAim.card); // Add this line
             }
             return;
         }
@@ -149,6 +153,8 @@ public class CastingUI
         {
             aiming = false;
             NetworkManager.HandleCast(cardToAim!.card, new((int)shipCoords.X, (int)shipCoords.Y));
+            
+            RemoveCardFromHand(cardToAim.card);
         }
     }
 
@@ -212,6 +218,8 @@ public class CastingUI
             {
                 aiming = false;
                 NetworkManager.HandleCast(cardToAim!.card, hoveredCoords.Value);
+                
+                RemoveCardFromHand(cardToAim.card);
             }
         }
     }
@@ -239,6 +247,8 @@ public class CastingUI
         {
             aiming = false;
             NetworkManager.HandleCast(cardToAim!.card, new((int)shipCoords.X, (int)shipCoords.Y));
+            
+            RemoveCardFromHand(cardToAim.card);
         }
     }
 
@@ -370,6 +380,8 @@ public class CastingUI
                         selectedShipIndex,
                         new Point(hoveredCoords.Value.X, hoveredCoords.Value.Y)
                     );
+                    
+                    RemoveCardFromHand(cardToAim.card);
                 }
             }
 
@@ -379,5 +391,15 @@ public class CastingUI
                 selectedShipIndex = -1;
             }
         }
+    }
+
+    /// <summary>
+    /// Removes a Card from the player's hand after casting it.
+    /// </summary>
+    /// <param name="card">The Card that will be removed</param>
+    private void RemoveCardFromHand(Cards card)
+    {
+        var playerHand = GameScreen.playerHand;
+        playerHand?.RemoveCard(card);
     }
 }

--- a/src/WaterWizard.Client/gamescreen/cards/GameHand.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/GameHand.cs
@@ -85,6 +85,8 @@ public class GameHand(GameScreen gameScreen, int centralX, int cardY)
     internal virtual void HandleCast(GameCard gameCard)
     {
         CastingUI.Instance.StartDrawingCardAim(gameCard);
+        
+        RemoveCard(gameCard);
     }
 
     /// <summary>
@@ -150,5 +152,27 @@ public class GameHand(GameScreen gameScreen, int centralX, int cardY)
     public void EmptyHand()
     {
         Cards.Clear();
+    }
+
+    /// <summary>
+    /// Removes a Card from the Hand by its GameCard instance.
+    /// </summary>
+    /// <param name="cardToRemove">The Card that will be removed after Casting</param>
+    public void RemoveCard(GameCard cardToRemove)
+    {
+        Cards.Remove(cardToRemove);
+    }
+
+    /// <summary>
+    /// Removes a Card from the Hand by its Cards enum value.
+    /// </summary>
+    /// <param name="cardToRemove">The Card that will be removed after Casting</param>
+    public void RemoveCard(Cards cardToRemove)
+    {
+        var gameCard = Cards.Find(gc => gc.card == cardToRemove);
+        if (gameCard != null)
+        {
+            Cards.Remove(gameCard);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to manage player hands both client-side and server-side, ensuring that cards are removed from a player's hand after casting. It also adds server-side validation for card removal and initializes player hands when players join the game. The changes improve synchronization between client and server states and enhance the game's robustness.

### Client-side changes:

* **Added card removal logic to `CastingUI`:** Introduced the `RemoveCardFromHand` method to remove cards from the player's hand after casting. This method is now called in multiple casting-related methods, such as `HandleShipTargeted`, `HandleTargeted`, and `HandleTeleportCard`. [[1]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR30-R31) [[2]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR52) [[3]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR84) [[4]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR156-R157) [[5]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR221-R222) [[6]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR250-R251) [[7]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR383-R384) [[8]](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR395-R404)
* **Enhanced `GameHand` functionality:** Added two overloads of the `RemoveCard` method to remove cards either by their `GameCard` instance or `Cards` enum value. This provides flexibility in card removal operations.

### Server-side changes:

* **Introduced player hand tracking:** Added a `PlayerHands` dictionary in `GameState` to track the cards each player has in their hand. This ensures server-side validation and synchronization.
* **Implemented card removal and initialization methods:** Added `RemoveCardFromPlayerHand` to remove cards from a player's hand on the server side and `InitializePlayerHand` to set up an empty hand for new players. These methods maintain server-side integrity and handle edge cases like players joining the game.…r-side hand management