### PR TITLE
Add cancel casting functionalitywith right click and clean up card re…

### DIFF
--- a/src/WaterWizard.Client/gamescreen/GameScreen.cs
+++ b/src/WaterWizard.Client/gamescreen/GameScreen.cs
@@ -6,6 +6,7 @@ using WaterWizard.Client.gamescreen.ships;
 using WaterWizard.Client.network;
 using WaterWizard.Shared;
 using WaterWizard.Client.gamestates;
+using System.Security.Cryptography;
 
 namespace WaterWizard.Client.gamescreen;
 
@@ -560,15 +561,11 @@ public class GameScreen(
                 card.card.Update(deltaTime);
             }
         }
-    }
+        if (Raylib.IsMouseButtonPressed(MouseButton.Right))
+        {
+            CastingUI.Instance.CancelCasting();
+        }
 
-    private void CreateThunderStrike(GameBoard board)
-    {
-        // Zufällige Position für den 2x2 Einschlag finden
-        int x = Random.Shared.Next(0, board.GridWidth - 1);
-        int y = Random.Shared.Next(0, board.GridHeight - 1);
-
-        board.AddThunderStrike(x, y);
     }
 
     public void EnableSingleShipPlacement()

--- a/src/WaterWizard.Client/gamescreen/cards/CastingUI.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/CastingUI.cs
@@ -49,7 +49,7 @@ public class CastingUI
         {
             aiming = false;
             NetworkManager.HandleCast(gameCard.card, new Point(0, 0));
-            RemoveCardFromHand(gameCard.card); 
+            RemoveCardFromHand(gameCard.card);
             return;
         }
 
@@ -153,7 +153,7 @@ public class CastingUI
         {
             aiming = false;
             NetworkManager.HandleCast(cardToAim!.card, new((int)shipCoords.X, (int)shipCoords.Y));
-            
+
             RemoveCardFromHand(cardToAim.card);
         }
     }
@@ -218,7 +218,7 @@ public class CastingUI
             {
                 aiming = false;
                 NetworkManager.HandleCast(cardToAim!.card, hoveredCoords.Value);
-                
+
                 RemoveCardFromHand(cardToAim.card);
             }
         }
@@ -247,7 +247,7 @@ public class CastingUI
         {
             aiming = false;
             NetworkManager.HandleCast(cardToAim!.card, new((int)shipCoords.X, (int)shipCoords.Y));
-            
+
             RemoveCardFromHand(cardToAim.card);
         }
     }
@@ -380,7 +380,7 @@ public class CastingUI
                         selectedShipIndex,
                         new Point(hoveredCoords.Value.X, hoveredCoords.Value.Y)
                     );
-                    
+
                     RemoveCardFromHand(cardToAim.card);
                 }
             }
@@ -401,5 +401,20 @@ public class CastingUI
     {
         var playerHand = GameScreen.playerHand;
         playerHand?.RemoveCard(card);
+    }
+    
+    /// <summary>
+    /// Cancels the current card casting process and resets all casting-related state.
+    /// This stops the aiming phase and clears any selected targets without executing the cast.
+    /// </summary>
+    public void CancelCasting()
+    {
+        if (aiming)
+        {
+            aiming = false;
+            cardToAim = null;
+            isTeleportSelectionPhase = false;
+            selectedShipIndex = -1;
+        }
     }
 }

--- a/src/WaterWizard.Client/gamescreen/cards/GameHand.cs
+++ b/src/WaterWizard.Client/gamescreen/cards/GameHand.cs
@@ -85,8 +85,6 @@ public class GameHand(GameScreen gameScreen, int centralX, int cardY)
     internal virtual void HandleCast(GameCard gameCard)
     {
         CastingUI.Instance.StartDrawingCardAim(gameCard);
-        
-        RemoveCard(gameCard);
     }
 
     /// <summary>

--- a/src/WaterWizard.Client/gamescreen/handler/HandleCards.cs
+++ b/src/WaterWizard.Client/gamescreen/handler/HandleCards.cs
@@ -81,7 +81,7 @@ public class HandleCards
             );
         }
     }
-    
+
     /// <summary>
     /// Handles the casting of the teleport card with ship selection and destination.
     /// </summary>
@@ -95,12 +95,12 @@ public class HandleCards
             NetDataWriter writer = new();
             writer.Put("CastCard");
             writer.Put(card.Variant.ToString());
-            
+
             // Encode ship ID in the higher 16 bits of X coordinate
             int encodedX = (shipId << 16) | (destinationCoords.X & 0xFFFF);
             writer.Put(encodedX);
             writer.Put(destinationCoords.Y);
-            
+
             clientService.client.FirstPeer.Send(writer, DeliveryMethod.ReliableOrdered);
             Console.WriteLine($"[Client] Teleport-Karte wirken: Schiff {shipId} zur Position ({destinationCoords.X}, {destinationCoords.Y})");
         }
@@ -109,6 +109,35 @@ public class HandleCards
             Console.WriteLine(
                 "[Client] Kein Server verbunden, Teleport konnte nicht gesendet werden."
             );
+        }
+    }
+    
+    /// <summary>
+    /// Handles notification that the opponent used a card
+    /// </summary>
+    /// <param name="reader">The NetPacketReader containing the card information</param>
+    public static void HandleOpponentUsedCard(NetPacketReader reader)
+    {
+        Console.WriteLine("[Client] Received OpponentUsedCard message");
+        var cardVariant = reader.GetString();
+        Console.WriteLine($"[Client] Card variant: {cardVariant}");
+        
+        if (Enum.TryParse<CardVariant>(cardVariant, out var variant))
+        {
+            var opponentHand = GameStateManager.Instance.GameScreen.opponentHand;
+            if (opponentHand != null && opponentHand.Cards.Count > 0)
+            {
+                opponentHand.Cards.RemoveAt(0);
+                Console.WriteLine($"[Client] Opponent used card {variant}, removed from opponent hand display. Remaining cards: {opponentHand.Cards.Count}");
+            }
+            else
+            {
+                Console.WriteLine($"[Client] Could not remove card - opponent hand is null or empty");
+            }
+        }
+        else
+        {
+            Console.WriteLine($"[Client] Failed to parse card variant: {cardVariant}");
         }
     }
 }

--- a/src/WaterWizard.Client/network/ClientService.cs
+++ b/src/WaterWizard.Client/network/ClientService.cs
@@ -435,6 +435,9 @@ public class ClientService(NetworkManager manager)
                 case "SummonShip":
                     GameStateManager.Instance.GameScreen.EnableSingleShipPlacement();
                     break;
+                case "OpponentUsedCard":
+                    HandleCards.HandleOpponentUsedCard(reader);
+                    break;
             }
         }
         catch (Exception ex)

--- a/src/WaterWizard.Server/GameState.cs
+++ b/src/WaterWizard.Server/GameState.cs
@@ -94,7 +94,7 @@ public class GameState
     /// Key: NetPeer representing the player
     /// Value: List of Cards representing the player's current hand
     /// </summary>
-    public Dictionary<NetPeer, List<Cards>> PlayerHands { get; private set; } = new();
+    public Dictionary<NetPeer, List<Cards>> PlayerHands { get; set; } = [];
 
 
     public bool IsPlacementPhase()


### PR DESCRIPTION
This pull request introduces improvements to the `GameScreen` and `CastingUI` functionalities in the `WaterWizard.Client` project. The most significant changes include adding a method to cancel the card casting process, modifying the behavior when the right mouse button is pressed, and improving code clarity by removing redundant operations during card casting.

Enhancements to casting functionality:

* [`src/WaterWizard.Client/gamescreen/cards/CastingUI.cs`](diffhunk://#diff-f6e56aa0697abc27bcfad3ec5c3506be1dfd74622bdd873b4ccb70d3528aee8dR405-R419): Added a new `CancelCasting` method to handle the cancellation of the card casting process, resetting all related states such as aiming, selected targets, and teleport selection phase.

Interaction updates:

* [`src/WaterWizard.Client/gamescreen/GameScreen.cs`](diffhunk://#diff-c38527117831c7c5228cc4fa600893a8d8815abf29c4a0836432211390ea31cbL563-L571): Updated the `Update` method to cancel the casting process when the right mouse button is pressed using the newly added `CancelCasting` method from `CastingUI`.

Code cleanup:

* [`src/WaterWizard.Client/gamescreen/cards/GameHand.cs`](diffhunk://#diff-c49ce3373595c856157aba72860e01605cc6e0751b99af3c3184289d5caf61ddL88-L89): Removed redundant `RemoveCard` operation in the `HandleCast` method to simplify the card casting logic.

Dependency addition:

* [`src/WaterWizard.Client/gamescreen/GameScreen.cs`](diffhunk://#diff-c38527117831c7c5228cc4fa600893a8d8815abf29c4a0836432211390ea31cbR9): Added `System.Security.Cryptography` namespace import, though its usage is not evident in the provided changes.