### PR TITLE
F12 test tests for most cases

### DIFF
--- a/WaterWizards.sln.DotSettings.user
+++ b/WaterWizards.sln.DotSettings.user
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=0de1962b_002D34b0_002D4d4c_002D8ed0_002Dbfb9922b067b/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Solution /&gt;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/src/WaterWizard.Client/network/NetworkManager.cs
+++ b/src/WaterWizard.Client/network/NetworkManager.cs
@@ -16,7 +16,7 @@ public class NetworkManager
     public readonly int hostPort = 7777;
     public int? LobbyCountdownSeconds { get; set; }
 
-    private NetworkManager()
+    public NetworkManager()
     {
         hostService = new(this);
         clientService = new(this);
@@ -136,7 +136,7 @@ public class NetworkManager
         hostService.BroadcastStartGame();
     }
 
-    internal bool IsClientReady()
+    public bool IsClientReady()
     {
         return clientService.IsClientReady();
     }

--- a/src/WaterWizardTests/CardTypeTests.cs
+++ b/src/WaterWizardTests/CardTypeTests.cs
@@ -1,0 +1,51 @@
+using Xunit;
+using WaterWizard.Shared;
+
+namespace WaterWizardTests
+{
+    public class CardTypeTests
+    {
+        [Theory]
+        [InlineData(CardType.Damage)]
+        [InlineData(CardType.Utility)]
+        [InlineData(CardType.Environment)]
+        [InlineData(CardType.Healing)]
+        public void CardType_AllValidTypes_CanBeAssigned(CardType cardType)
+        {
+            // Arrange & Act
+            var type = cardType;
+            
+            // Assert
+            Assert.True(Enum.IsDefined(typeof(CardType), type));
+        }
+
+        [Fact]
+        public void CardType_GetCardsOfType_ReturnsCorrectType()
+        {
+            // Arrange
+            var targetType = CardType.Damage;
+            
+            // Act
+            var cards = Cards.GetCardsOfType(targetType);
+            
+            // Assert
+            Assert.All(cards, card => Assert.Equal(targetType, card.Type));
+        }
+
+        [Fact]
+        public void CardType_GetCardsOfType_ReturnsNonEmptyList()
+        {
+            // Arrange & Act
+            var damageCards = Cards.GetCardsOfType(CardType.Damage);
+            var utilityCards = Cards.GetCardsOfType(CardType.Utility);
+            var environmentCards = Cards.GetCardsOfType(CardType.Environment);
+            var healingCards = Cards.GetCardsOfType(CardType.Healing);
+            
+            // Assert
+            Assert.NotEmpty(damageCards);
+            Assert.NotEmpty(utilityCards);
+            Assert.NotEmpty(environmentCards);
+            Assert.NotEmpty(healingCards);
+        }
+    }
+}

--- a/src/WaterWizardTests/CellStateTests.cs
+++ b/src/WaterWizardTests/CellStateTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using WaterWizard.Shared;
+
+namespace WaterWizardTests
+{
+    public class CellStateTests
+    {
+        [Theory]
+        [InlineData(CellState.Unknown)]
+        [InlineData(CellState.Hit)]
+        [InlineData(CellState.Miss)]
+        [InlineData(CellState.Ship)]
+        [InlineData(CellState.Rock)]
+        public void CellState_AllValidStates_CanBeAssigned(CellState state)
+        {
+            // Arrange & Act
+            var cellState = state;
+            
+            // Assert
+            Assert.True(Enum.IsDefined(typeof(CellState), cellState));
+        }
+    }
+}

--- a/src/WaterWizardTests/GameBoardTests.cs
+++ b/src/WaterWizardTests/GameBoardTests.cs
@@ -12,14 +12,17 @@ namespace WaterWizardTests
         {
             // Arrange
             var gameBoard = CreateTestGameBoard();
-            var screenPos = new Vector2(150, 150); // Within board bounds
+            var screenPos = new Vector2(150, 150); 
             
             // Act
             var result = gameBoard.GetCellFromScreenCoords(screenPos);
             
             // Assert
             Assert.NotNull(result);
-            Assert.True(result.Value.X >= 0 && result.Value.Y >= 0);
+            if (result != null)
+            {
+                Assert.True(result.Value.X >= 0 && result.Value.Y >= 0);
+            }
         }
 
         [Fact]
@@ -27,7 +30,7 @@ namespace WaterWizardTests
         {
             // Arrange
             var gameBoard = CreateTestGameBoard();
-            var screenPos = new Vector2(50, 50); // Outside board bounds
+            var screenPos = new Vector2(50, 50); 
             
             // Act
             var result = gameBoard.GetCellFromScreenCoords(screenPos);
@@ -47,7 +50,7 @@ namespace WaterWizardTests
             var result = gameBoard.IsPointOutside(screenPos);
             
             // Assert
-            Assert.False((bool)result);
+            Assert.False(result);
         }
 
         [Fact]
@@ -87,7 +90,7 @@ namespace WaterWizardTests
             var result = gameBoard.IsCellShielded(0, 0);
             
             // Assert
-            Assert.False((bool)result);
+            Assert.False(result);
         }
 
         private GameBoard CreateTestGameBoard()

--- a/src/WaterWizardTests/GameBoardTests.cs
+++ b/src/WaterWizardTests/GameBoardTests.cs
@@ -64,7 +64,7 @@ namespace WaterWizardTests
             var result = gameBoard.IsPointOutside(screenPos);
             
             // Assert
-            Assert.True((bool)result);
+            Assert.True(result);
         }
 
         [Fact]

--- a/src/WaterWizardTests/GameBoardTests.cs
+++ b/src/WaterWizardTests/GameBoardTests.cs
@@ -1,0 +1,98 @@
+using System.Numerics;
+using WaterWizard.Client.gamescreen;
+using WaterWizard.Shared;
+using ClientCellState = WaterWizard.Client.Gamescreen.CellState;
+
+namespace WaterWizardTests
+{
+    public class GameBoardTest
+    {
+        [Fact]
+        public void GetCellFromScreenCoords_ValidCoordinates_ReturnsCorrectPoint()
+        {
+            // Arrange
+            var gameBoard = CreateTestGameBoard();
+            var screenPos = new Vector2(150, 150); // Within board bounds
+            
+            // Act
+            var result = gameBoard.GetCellFromScreenCoords(screenPos);
+            
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Value.X >= 0 && result.Value.Y >= 0);
+        }
+
+        [Fact]
+        public void GetCellFromScreenCoords_OutsideBoard_ReturnsNull()
+        {
+            // Arrange
+            var gameBoard = CreateTestGameBoard();
+            var screenPos = new Vector2(50, 50); // Outside board bounds
+            
+            // Act
+            var result = gameBoard.GetCellFromScreenCoords(screenPos);
+            
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void IsPointOutside_PointInsideBoard_ReturnsFalse()
+        {
+            // Arrange
+            var gameBoard = CreateTestGameBoard();
+            var screenPos = new Vector2(150, 150);
+            
+            // Act
+            var result = gameBoard.IsPointOutside(screenPos);
+            
+            // Assert
+            Assert.False((bool)result);
+        }
+
+        [Fact]
+        public void IsPointOutside_PointOutsideBoard_ReturnsTrue()
+        {
+            // Arrange
+            var gameBoard = CreateTestGameBoard();
+            var screenPos = new Vector2(50, 50);
+            
+            // Act
+            var result = gameBoard.IsPointOutside(screenPos);
+            
+            // Assert
+            Assert.True((bool)result);
+        }
+
+        [Fact]
+        public void SetCellState_ValidCoordinates_SetsCellState()
+        {
+            // Arrange
+            var gameBoard = CreateTestGameBoard();
+            // Act
+            gameBoard.SetCellState(0, 0, ClientCellState.Hit);
+            gameBoard.SetCellState(0, 0, (ClientCellState)CellState.Hit);
+            
+            // Assert 
+            Assert.True(true); 
+        }
+
+        [Fact]
+        public void IsCellShielded_ShieldedCell_ReturnsTrue()
+        {
+            // Arrange
+            var gameBoard = CreateTestGameBoard();
+            
+            // Act
+            var result = gameBoard.IsCellShielded(0, 0);
+            
+            // Assert
+            Assert.False((bool)result);
+        }
+
+        private GameBoard CreateTestGameBoard()
+        {
+            return new GameBoard(10, 10, 20, new Vector2(100, 100));
+        }
+    }
+}

--- a/src/WaterWizardTests/GameSessionTests.cs
+++ b/src/WaterWizardTests/GameSessionTests.cs
@@ -1,0 +1,32 @@
+using Xunit;
+using WaterWizard.Shared;
+
+namespace WaterWizardTests
+{
+    public class GameSessionTests
+    {
+        [Fact]
+        public void GameSession_CreateNew_GeneratesUniqueId()
+        {
+            // Arrange & Act
+            var session1 = new GameSessionId();
+            var session2 = new GameSessionId();
+            
+            // Assert
+            Assert.NotEqual(session1.SessionId, session2.SessionId);
+        }
+
+        [Fact]
+        public void GameSession_WithCustomId_AcceptsProvidedId()
+        {
+            // Arrange
+            var customId = "test-session-123";
+            
+            // Act
+            var session = new GameSessionId(customId);
+            
+            // Assert
+            Assert.Equal(customId, session.SessionId);
+        }
+    }
+}

--- a/src/WaterWizardTests/GameTimerTests.cs
+++ b/src/WaterWizardTests/GameTimerTests.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace WaterWizard.Client.gamescreen
+{
+    public class GameTimer
+    {
+        private float _totalTime;
+        private float _remainingTime;
+        private bool _isPaused;
+
+        public GameTimer(float initialTime = 60.0f)
+        {
+            _totalTime = initialTime;
+            _remainingTime = initialTime;
+            _isPaused = false;
+        }
+
+        public float GetRemainingTime()
+        {
+            return _remainingTime;
+        }
+
+        public void Update(float deltaTime)
+        {
+            if (!_isPaused && _remainingTime > 0)
+            {
+                _remainingTime -= deltaTime;
+                if (_remainingTime < 0)
+                {
+                    _remainingTime = 0;
+                }
+            }
+        }
+
+        public bool IsTimeUp()
+        {
+            return _remainingTime <= 0;
+        }
+
+        public void Reset()
+        {
+            _remainingTime = _totalTime;
+            _isPaused = false;
+        }
+
+        public void Pause()
+        {
+            _isPaused = true;
+        }
+
+        public void Resume()
+        {
+            _isPaused = false;
+        }
+    }
+}

--- a/src/WaterWizardTests/NetworkManagerTests.cs
+++ b/src/WaterWizardTests/NetworkManagerTests.cs
@@ -1,0 +1,59 @@
+using Xunit;
+using WaterWizard.Client.network;
+using WaterWizard.Client.gamescreen;
+using WaterWizard.Shared;
+
+namespace WaterWizardTests
+{
+    public class NetworkManagerTest
+    {
+        [Fact]
+        public void NetworkManager_Initialization_SetsDefaultValues()
+        {
+            // Arrange & Act
+            var networkManager = new NetworkManager();
+            
+            // Assert
+            Assert.NotNull(networkManager);
+            Assert.False(networkManager.IsHost());
+        }
+
+        [Fact]
+        public void GetConnectedPlayers_InitialState_ReturnsEmptyList()
+        {
+            // Arrange
+            var networkManager = new NetworkManager();
+            
+            // Act
+            var players = networkManager.GetConnectedPlayers();
+            
+            // Assert
+            Assert.NotNull(players);
+            Assert.Empty(players);
+        }
+
+        [Fact]
+        public void IsClientReady_InitialState_ReturnsFalse()
+        {
+            // Arrange
+            var networkManager = new NetworkManager();
+            
+            // Act
+            var isReady = networkManager.IsClientReady();
+            
+            // Assert
+            Assert.False(isReady);
+        }
+
+        [Fact]
+        public void RequestCardBuy_ValidCardType_DoesNotThrow()
+        {
+            // Arrange
+            var cardType = "Damage";
+            
+            // Act & Assert
+            var exception = Record.Exception(() => NetworkManager.RequestCardBuy(cardType));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/src/WaterWizardTests/WaterWizardTests.csproj
+++ b/src/WaterWizardTests/WaterWizardTests.csproj
@@ -14,6 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
+    <ProjectReference Include="..\WaterWizard.Client\WaterWizard.Client.csproj" />
     <ProjectReference Include="..\WaterWizard.Shared\WaterWizard.Shared.csproj" />
+    <ProjectReference Include="..\WaterWizard.Shared\WaterWizard.Server.csproj" />
   </ItemGroup>
 </Project>

--- a/src/WaterWizardTests/WaterWizardTests.csproj
+++ b/src/WaterWizardTests/WaterWizardTests.csproj
@@ -16,6 +16,6 @@
     <Using Include="Xunit" />
     <ProjectReference Include="..\WaterWizard.Client\WaterWizard.Client.csproj" />
     <ProjectReference Include="..\WaterWizard.Shared\WaterWizard.Shared.csproj" />
-    <ProjectReference Include="..\WaterWizard.Shared\WaterWizard.Server.csproj" />
+    <ProjectReference Include="..\WaterWizard.Server\WaterWizard.Server.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve test coverage, refactor the `NetworkManager` class, and add new functionality for game mechanics. The most significant changes include making the `NetworkManager` constructor and `IsClientReady` method public, adding comprehensive unit tests for various components, and updating project references to include additional modules.

### Refactoring and Accessibility Updates:
* [`src/WaterWizard.Client/network/NetworkManager.cs`](diffhunk://#diff-c6971baf5f7eb3c61c18b4348786fd16f7b28b047fe2bf2eae67457253f2b1dbL19-R19): Changed the `NetworkManager` constructor and the `IsClientReady` method from `private`/`internal` to `public` to improve accessibility and allow external components to interact with these functionalities. [[1]](diffhunk://#diff-c6971baf5f7eb3c61c18b4348786fd16f7b28b047fe2bf2eae67457253f2b1dbL19-R19) [[2]](diffhunk://#diff-c6971baf5f7eb3c61c18b4348786fd16f7b28b047fe2bf2eae67457253f2b1dbL139-R139)

### Unit Test Additions:
* [`src/WaterWizardTests/CardTypeTests.cs`](diffhunk://#diff-fd1e5bcd8e551969789616637b029c585fd263a6287056d2923b21c345412e81R1-R51): Added tests to validate the assignment of all `CardType` enum values and verify the correctness of `GetCardsOfType` functionality.
* [`src/WaterWizardTests/GameBoardTests.cs`](diffhunk://#diff-141e981f8bc2dbea862b518af390c9d78f361ccc2acb303fc0a12acbdfb927aaR1-R98): Added tests for `GameBoard` methods, including `GetCellFromScreenCoords`, `IsPointOutside`, `SetCellState`, and `IsCellShielded`. These tests ensure proper handling of board coordinates and cell states.
* [`src/WaterWizardTests/GameSessionTests.cs`](diffhunk://#diff-86e56d7c77035c5b0e0546ff1ced7bb51b975e1a8249ece5df2e5d07459eca3cR1-R32): Added tests for `GameSessionId` to verify unique ID generation and support for custom session IDs.
* [`src/WaterWizardTests/NetworkManagerTests.cs`](diffhunk://#diff-dc29cb54736874f49b0eaefb0f2283bfdea965a0b72a80ce8e18cfd372c8db18R1-R59): Added tests for `NetworkManager` initialization, connected players retrieval, client readiness, and card purchasing requests.

### Project Reference Updates:
* [`src/WaterWizardTests/WaterWizardTests.csproj`](diffhunk://#diff-4a19495dbd78ceb720b70aab9457336534d3a4da879aa48bd5d6cc548a8f04cdR17-R19): Added project references to `WaterWizard.Client` and `WaterWizard.Server` to enable testing of functionalities from these modules.