### PR TITLE
hoveringeye card fixed

### DIFF
--- a/src/WaterWizard.Client/gamescreen/GameBoard.cs
+++ b/src/WaterWizard.Client/gamescreen/GameBoard.cs
@@ -317,18 +317,12 @@ public class GameBoard
     /// </summary>
     public void Draw()
     {
-        // Zeichne das Grundbrett
+        // Use DrawCell instead of the inline drawing
         for (int x = 0; x < GridWidth; x++)
         {
             for (int y = 0; y < GridHeight; y++)
             {
-                int posX = (int)Position.X + x * CellSize;
-                int posY = (int)Position.Y + y * CellSize;
-
-                // Zeichne die Grundfarbe der Zelle
-                Color cellColor = GetColorForState(_gridStates[x, y]);
-                Raylib.DrawRectangle(posX, posY, CellSize, CellSize, cellColor);
-                Raylib.DrawRectangleLines(posX, posY, CellSize, CellSize, Color.DarkGray);
+                DrawCell(x, y);
             }
         }
 
@@ -405,14 +399,14 @@ public class GameBoard
         return state switch
         {
             CellState.Empty => Color.LightGray,
-            // CellState.Ship => Color.Gray, //because of texture now blank
             CellState.Ship => Color.Blank,
             CellState.Rock => Color.DarkGray,
             CellState.Hit => Color.Blank,
             CellState.Miss => Color.Blue,
-            CellState.Unknown => new Color(135, 206, 235, 0), //transparenz hinzugefügt um den background sichtbar zu machen 
-            CellState.Thunder => new Color(30, 30, 150, 255), // Dunkelblau für Thunder
-            CellState.Shield => new Color(0, 255, 255, 100), // Cyan für Shield mit Transparenz
+            CellState.Unknown => new Color(135, 206, 235, 0),
+            CellState.Thunder => new Color(30, 30, 150, 255),
+            CellState.Shield => new Color(0, 255, 255, 100),
+            CellState.HoveringEyeRevealed => new Color(25, 25, 112, 255), // Dark blue for empty revealed cells
             _ => Color.Black,
         };
     }
@@ -557,12 +551,13 @@ public class GameBoard
         {
             if (hasShip)
             {
-                _gridStates[x, y] = CellState.Ship;
+                _gridStates[x, y] = CellState.Ship; 
             }
             else
             {
-                _gridStates[x, y] = CellState.HoveringEyeRevealed;
+                _gridStates[x, y] = CellState.HoveringEyeRevealed; 
             }
+            Console.WriteLine($"[GameBoard] HoveringEye revealed cell ({x},{y}) = {(hasShip ? "ship" : "empty")}");
         }
     }
 
@@ -740,48 +735,32 @@ public class GameBoard
         int cellX = (int)Position.X + x * CellSize;
         int cellY = (int)Position.Y + y * CellSize;
 
-        switch (_gridStates[x, y])
+        Color cellColor = _gridStates[x, y] switch
         {
-            case CellState.Empty:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, Color.LightGray);
-                break;
-            case CellState.Ship:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, Color.Gray);
-                break;
-            case CellState.Rock:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, Color.DarkGray);
-                break;
-            case CellState.Hit:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, Color.Orange);
-                break;
-            case CellState.Miss:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, Color.DarkBlue);
-                break;
-            case CellState.Shield:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, GetColorForState(CellState.Shield));
-                break;
-            case CellState.Unknown:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, new Color(135, 206, 235, 0));
-                break;
-            case CellState.Thunder:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, new Color(30, 30, 150, 255));
-                break;
-            case CellState.HoveringEyeRevealed:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, new Color(100, 150, 255, 100));
-                Raylib.DrawRectangleLines(cellX, cellY, CellSize, CellSize, Color.Blue);
-                break;
-            default:
-                Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, Color.Black);
-                break;
+            CellState.Empty => Color.LightGray,
+            CellState.Ship => this == GameStateManager.Instance.GameScreen?.playerBoard ? Color.Blank : Color.Orange, // Blank for player's board, Orange for opponent's board
+            CellState.Rock => Color.DarkGray,
+            CellState.Hit => Color.Orange,
+            CellState.Miss => Color.DarkBlue,
+            CellState.Unknown => new Color(135, 206, 235, 0),
+            CellState.Thunder => new Color(30, 30, 150, 255),
+            CellState.Shield => new Color(0, 255, 255, 100),
+            CellState.HoveringEyeRevealed => new Color(25, 25, 112, 255),
+            _ => Color.Black,
+        };
+
+        Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, cellColor);
+
+        if (_gridStates[x, y] == CellState.HoveringEyeRevealed)
+        {
+            Raylib.DrawRectangleLines(cellX, cellY, CellSize, CellSize, new Color(255, 255, 0, 200)); 
         }
 
-        // Draw shield effect overlay if cell is shielded
         if (IsCellShielded(x, y))
         {
             float duration = _shieldedCells[(x, y)];
-            float alpha = Math.Min(1.0f, duration / 6.0f); // Fade out as duration decreases
-            Color shieldColor = new Color(0, 255, 255, (int)(150 * alpha)); // Cyan with transparency
-
+            float alpha = Math.Min(1.0f, duration / 6.0f);
+            Color shieldColor = new Color(0, 255, 255, (int)(150 * alpha));
             Raylib.DrawRectangle(cellX, cellY, CellSize, CellSize, shieldColor);
             Raylib.DrawRectangleLines(cellX, cellY, CellSize, CellSize, new Color(0, 200, 200, (int)(255 * alpha)));
         }
@@ -837,5 +816,16 @@ public class GameBoard
     {
         _shieldedCells.Clear();
         Console.WriteLine("[GameBoard] All shield effects cleared");
+    }
+
+    public void AddHoveringEyeHighlight(int startX, int startY, int width, int height)
+    {
+        int cellX = (int)Position.X + startX * CellSize;
+        int cellY = (int)Position.Y + startY * CellSize;
+        int rectWidth = width * CellSize;
+        int rectHeight = height * CellSize;
+        
+        Raylib.DrawRectangleLines(cellX - 2, cellY - 2, rectWidth + 4, rectHeight + 4, new Color(255, 255, 0, 255));
+        Raylib.DrawRectangleLines(cellX - 1, cellY - 1, rectWidth + 2, rectHeight + 2, new Color(255, 255, 0, 200));
     }
 }

--- a/src/WaterWizard.Client/gamescreen/handler/HandleUtility.cs
+++ b/src/WaterWizard.Client/gamescreen/handler/HandleUtility.cs
@@ -116,29 +116,30 @@ public class HandleUtility
         bool hasShip = reader.GetBool();
         bool isOpponent = reader.GetBool();
 
+        Console.WriteLine($"[CLIENT] HoveringEye message received: ({revealX},{revealY}) hasShip={hasShip} isOpponent={isOpponent}");
+
         var gameScreen = GameStateManager.Instance.GameScreen;
         if (gameScreen != null)
         {
             if (isOpponent)
             {
-                var playerBoard = gameScreen.playerBoard;
-                if (playerBoard != null)
-                {
-                    playerBoard.MarkCellAsHoveringEyeRevealed(revealX, revealY, hasShip);
-                    Console.WriteLine(
-                        $"[Client] Opponent - HoveringEye revealed on own board: ({revealX},{revealY}) = {(hasShip ? "ship present" : "empty")}"
-                    );
-                }
-            }
-            else
-            {
                 var opponentBoard = gameScreen.opponentBoard;
                 if (opponentBoard != null)
                 {
                     opponentBoard.MarkCellAsHoveringEyeRevealed(revealX, revealY, hasShip);
-                    Console.WriteLine(
-                        $"[Client] Caster - HoveringEye revealed on opponent board: ({revealX},{revealY}) = {(hasShip ? "ship present" : "empty")}"
-                    );
+                    Console.WriteLine($"[CLIENT] Updated opponent board cell ({revealX},{revealY}) with hasShip={hasShip}");
+                }
+            }
+            else
+            {
+                var playerBoard = gameScreen.playerBoard;
+                if (playerBoard != null)
+                {
+                    if (!hasShip)
+                    {
+                        playerBoard.MarkCellAsHoveringEyeRevealed(revealX, revealY, hasShip);
+                    }
+                    Console.WriteLine($"[CLIENT] Updated player board cell ({revealX},{revealY}) with hasShip={hasShip}");
                 }
             }
         }

--- a/src/WaterWizard.Server/Card/utility/HoveringEyeCard.cs
+++ b/src/WaterWizard.Server/Card/utility/HoveringEyeCard.cs
@@ -16,7 +16,7 @@ namespace WaterWizard.Server.Card.utility;
 
 /// <summary>
 /// Implementation of the HoveringEye utility card
-/// Reveals a 2x2 area without damaging ships
+/// Reveals a 2x1 area without damaging ships
 /// </summary>
 public class HoveringEyeCard : IUtilityCard
 {
@@ -32,6 +32,8 @@ public class HoveringEyeCard : IUtilityCard
         int startY = (int)targetCoords.Y;
 
         Console.WriteLine($"[Server] HoveringEye revealing 2x2 area at ({startX}, {startY})");
+
+        SendHoveringEyeAreaHighlight(caster, opponent, startX, startY, (int)AreaOfEffect.X, (int)AreaOfEffect.Y);
 
         for (int dx = 0; dx < (int)AreaOfEffect.X; dx++)
         {
@@ -84,7 +86,7 @@ public class HoveringEyeCard : IUtilityCard
         casterWriter.Put(x);
         casterWriter.Put(y);
         casterWriter.Put(hasShip);
-        casterWriter.Put(false); 
+        casterWriter.Put(true); 
         caster.Send(casterWriter, DeliveryMethod.ReliableOrdered);
 
         var opponentWriter = new LiteNetLib.Utils.NetDataWriter();
@@ -92,11 +94,32 @@ public class HoveringEyeCard : IUtilityCard
         opponentWriter.Put(x);
         opponentWriter.Put(y);
         opponentWriter.Put(hasShip);
-        opponentWriter.Put(true); 
+        opponentWriter.Put(false); 
         opponent.Send(opponentWriter, DeliveryMethod.ReliableOrdered);
 
         Console.WriteLine(
             $"[Server] HoveringEye reveal sent to both players: ({x},{y}) = {(hasShip ? "ship present" : "empty")}"
         );
+    }
+
+    private static void SendHoveringEyeAreaHighlight(NetPeer caster, NetPeer opponent, int startX, int startY, int width, int height)
+    {
+        var casterWriter = new LiteNetLib.Utils.NetDataWriter();
+        casterWriter.Put("HoveringEyeAreaHighlight");
+        casterWriter.Put(startX);
+        casterWriter.Put(startY);
+        casterWriter.Put(width);
+        casterWriter.Put(height);
+        casterWriter.Put(false); 
+        caster.Send(casterWriter, DeliveryMethod.ReliableOrdered);
+
+        var opponentWriter = new LiteNetLib.Utils.NetDataWriter();
+        opponentWriter.Put("HoveringEyeAreaHighlight");
+        opponentWriter.Put(startX);
+        opponentWriter.Put(startY);
+        opponentWriter.Put(width);
+        opponentWriter.Put(height);
+        opponentWriter.Put(true);
+        opponent.Send(opponentWriter, DeliveryMethod.ReliableOrdered);
     }
 }

--- a/src/WaterWizard.Server/CardAbilities.cs
+++ b/src/WaterWizard.Server/CardAbilities.cs
@@ -301,8 +301,31 @@ public static class CardAbilities
         var card = new Cards(variant);
         if (card.Type == CardType.Utility)
         {
-            // Verwende die übergebenen Handler
-            // utilityCardHandler.HandleUtilityCard(variant, targetCoords, caster, defender);
+            switch (variant)
+            {
+                case CardVariant.HoveringEye:
+                    var hoveringEyeCard = new HoveringEyeCard();
+                    if (hoveringEyeCard.IsValidTarget(gameState, targetCoords, caster, defender))
+                    {
+                        bool executed = hoveringEyeCard.ExecuteUtility(gameState, targetCoords, caster, defender);
+                        Console.WriteLine($"[Server] {variant} utility result: {(executed ? "executed successfully" : "execution failed")}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[Server] Invalid target for {variant} at ({targetCoords.X}, {targetCoords.Y})");
+                    }
+                    break;
+                case CardVariant.Paralize:
+                    var paralizeCard = new ParalizeCard();
+                    if (paralizeCard.IsValidTarget(gameState, targetCoords, caster, defender))
+                    {
+                        paralizeCard.ExecuteUtility(gameState, targetCoords, caster, defender);
+                    }
+                    break;
+                default:
+                    utilityCardHandler.HandleUtilityCard(variant, targetCoords, caster, defender);
+                    break;
+            }
             return;
         }
 

--- a/src/WaterWizard.Server/handler/CardHandler.cs
+++ b/src/WaterWizard.Server/handler/CardHandler.cs
@@ -190,8 +190,7 @@ public class CardHandler(GameState gameState)
                     Console.WriteLine($"[CardHandler] Player {peer} has no hand tracked on server - this might be normal for testing");
                 }
 
-
-                CardAbilities.HandleAbility(variant, gameState, new Vector2(cardX, cardY), peer, defender);
+                CardAbilities.HandleAbilityWithHandlers(variant, gameState, new Vector2(cardX, cardY), peer, defender, paralizeHandler, utilityCardHandler);
 
                 var cardToRemove = new Cards(variant);
                 bool cardRemoved = gameState.RemoveCardFromPlayerHand(peer, cardToRemove);


### PR DESCRIPTION
This pull request introduces enhancements to the HoveringEye utility card functionality, refactors drawing logic in the `GameBoard` class, and improves server-client communication for handling card abilities. Key changes include adding area highlights for the HoveringEye card, simplifying cell drawing logic, and refining the handling of utility cards on the server.

### HoveringEye Card Enhancements:
* Updated the HoveringEye card to reveal a 2x1 area instead of 2x2, and added logic to send area highlights to both players during execution. (`src/WaterWizard.Server/Card/utility/HoveringEyeCard.cs`, [[1]](diffhunk://#diff-166e15578d4b7119323f92939399d4cb4759f5d83c25e7e8a04463d1d46725d9L19-R19) [[2]](diffhunk://#diff-166e15578d4b7119323f92939399d4cb4759f5d83c25e7e8a04463d1d46725d9R36-R37) [[3]](diffhunk://#diff-166e15578d4b7119323f92939399d4cb4759f5d83c25e7e8a04463d1d46725d9L87-R124)
* Added client-side handling for HoveringEye area highlights, including drawing highlighted rectangles on the game board. (`src/WaterWizard.Client/gamescreen/GameBoard.cs`, [src/WaterWizard.Client/gamescreen/GameBoard.csR820-R830](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aR820-R830))

### GameBoard Refactoring:
* Refactored `DrawCell` to simplify cell drawing logic using a `switch` expression for color determination, and added support for HoveringEye-revealed cells. (`src/WaterWizard.Client/gamescreen/GameBoard.cs`, [src/WaterWizard.Client/gamescreen/GameBoard.csL743-R763](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aL743-R763))
* Replaced inline cell drawing in the `Draw` method with calls to the `DrawCell` method to improve maintainability. (`src/WaterWizard.Client/gamescreen/GameBoard.cs`, [src/WaterWizard.Client/gamescreen/GameBoard.csL320-R325](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aL320-R325))

### Logging and Debugging Improvements:
* Enhanced logging for HoveringEye actions, including server-side execution and client-side updates for revealed cells. (`src/WaterWizard.Client/gamescreen/GameBoard.cs`, [[1]](diffhunk://#diff-c59e8d7620f154e4c4dc5335905917b7c761e700b5281c3eaec8fd85895f460aR560); `src/WaterWizard.Client/gamescreen/handler/HandleUtility.cs`, [[2]](diffhunk://#diff-e62f2927bc948833c5d15e00b7027ee08d3c519770aac485cb7f086b5d5836a0R119-R142)

### Server-Side Utility Card Handling:
* Refined utility card handling to explicitly process HoveringEye and Paralize cards, falling back to generic handlers for other variants. (`src/WaterWizard.Server/CardAbilities.cs`, [src/WaterWizard.Server/CardAbilities.csL304-R328](diffhunk://#diff-ccf71f8ab7d7a80af946f01b2de95b5b22ec2b0b767a5f6c4437ad05f7a0550cL304-R328))
* Updated the card casting handler to use the new `HandleAbilityWithHandlers` method for improved modularity. (`src/WaterWizard.Server/handler/CardHandler.cs`, [src/WaterWizard.Server/handler/CardHandler.csL193-R193](diffhunk://#diff-14a85676b3e38930e9a4557f39e20286eb3bc990160f0094f55b056e6568521bL193-R193))