### PR TITLE
Shield Card fixed

### DIFF
--- a/src/WaterWizard.Server/handler/UtilityCardHandler.cs
+++ b/src/WaterWizard.Server/handler/UtilityCardHandler.cs
@@ -42,10 +42,14 @@ public class UtilityCardHandler
         {
             case CardVariant.Paralize:
                 Console.WriteLine($"[UtilityCardHandler] Paralize-Karte aktiviert!");
-                Console.WriteLine($"[UtilityCardHandler] Caster (Angreifer): {caster.ToString()} (Port: {caster.Port})");
-                Console.WriteLine($"[UtilityCardHandler] Defender (Ziel): {defender.ToString()} (Port: {defender.Port})");
+                Console.WriteLine($"[UtilityCardHandler] Caster (Angreifer): {caster} (Port: {caster.Port})");
+                Console.WriteLine($"[UtilityCardHandler] Defender (Ziel): {defender} (Port: {defender.Port})");
                 Console.WriteLine($"[UtilityCardHandler] Zielkoordinaten: ({targetCoords.X}, {targetCoords.Y})");
                 // paralizeHandler.HandleParalizeCard(caster, defender); //TODO:not needed if factory goes right
+                break;
+            case CardVariant.Shield:
+                Console.WriteLine($"[UtilityCardHandler] Shield-Karte aktiviert!");
+                HandleShield(targetCoords, caster, defender);
                 break;
             case CardVariant.HoveringEye:
                 Console.WriteLine($"[UtilityCardHandler] HoveringEye-Karte aktiviert!");
@@ -82,7 +86,7 @@ public class UtilityCardHandler
         int shipId = (int)(targetCoords.X) >> 16;
         int destinationX = (int)targetCoords.X & 0xFFFF;
         int destinationY = (int)targetCoords.Y;
-        
+
         Console.WriteLine($"[UtilityCardHandler] Teleport ship {shipId} to ({destinationX}, {destinationY})");
     }
 
@@ -111,5 +115,21 @@ public class UtilityCardHandler
     {
         // TODO: Implementiere Verwandlungseffekt
         Console.WriteLine($"[UtilityCardHandler] Polymorph at ({targetCoords.X}, {targetCoords.Y})");
+    }
+    
+    /// <summary>
+    /// Handelt die Shield-Karte (Schutzschild)
+    /// </summary>
+    private void HandleShield(Vector2 targetCoords, NetPeer caster, NetPeer defender)
+    {
+        var shieldCard = new Card.utility.ShieldCard();
+        if (shieldCard.IsValidTarget(gameState, targetCoords, caster, defender))
+        {
+            shieldCard.ExecuteUtility(gameState, targetCoords, caster, defender);
+        }
+        else
+        {
+            Console.WriteLine($"[UtilityCardHandler] Invalid target for Shield at ({targetCoords.X}, {targetCoords.Y})");
+        }
     }
 }


### PR DESCRIPTION
This pull request adds support for the "Shield" utility card in the `UtilityCardHandler` class, along with some minor code improvements for clarity. The most important changes include adding a new case for the "Shield" card in the `HandleUtilityCard` method and implementing the `HandleShield` method to execute the card's functionality.

### New functionality for the Shield card:
* [`src/WaterWizard.Server/handler/UtilityCardHandler.cs`](diffhunk://#diff-e91d6f7f96ebb76296d964f191eaef9b94240b00f6f224c1f37d8c48abf60771L45-R53): Added a new case for `CardVariant.Shield` in the `HandleUtilityCard` method to handle the activation of the Shield card.
* [`src/WaterWizard.Server/handler/UtilityCardHandler.cs`](diffhunk://#diff-e91d6f7f96ebb76296d964f191eaef9b94240b00f6f224c1f37d8c48abf60771R119-R134): Implemented the `HandleShield` method to validate the target and execute the Shield card's effect using the `ShieldCard` class.

### Code improvements:
* [`src/WaterWizard.Server/handler/UtilityCardHandler.cs`](diffhunk://#diff-e91d6f7f96ebb76296d964f191eaef9b94240b00f6f224c1f37d8c48abf60771L45-R53): Simplified `Console.WriteLine` calls by removing unnecessary `ToString()` calls for `caster` and `defender`.