### PR TITLE
B302: Inconsistent time for paralyze dot

### DIFF
--- a/src/WaterWizard.Server/handler/ManaHandler.cs
+++ b/src/WaterWizard.Server/handler/ManaHandler.cs
@@ -19,6 +19,7 @@ public class ManaHandler
 {
     private readonly GameState gameState;
     private readonly ParalizeHandler paralizeHandler;
+    private DateTime lastManaUpdate = DateTime.UtcNow; // Track last update time
 
     public ManaHandler(GameState gameState, ParalizeHandler paralizeHandler)
     {
@@ -31,8 +32,13 @@ public class ManaHandler
     /// </summary>
     public void UpdateMana()
     {
-        // Aktualisiere Paralize-Timer
-        paralizeHandler.UpdateParalizeTimers(4000f); // 4 Sekunden = 4000ms
+        // Berechne echte Delta-Zeit seit letztem Update
+        DateTime currentTime = DateTime.UtcNow;
+        float deltaTimeSeconds = (float)(currentTime - lastManaUpdate).TotalSeconds;
+        lastManaUpdate = currentTime;
+
+        // Aktualisiere Paralize-Timer mit korrekter Delta-Zeit
+        paralizeHandler.UpdateParalizeTimers(deltaTimeSeconds); // Verwende echte Delta-Zeit statt fixer 4000ms
 
         // Gebe Mana nur hinzu, wenn der Spieler nicht paralysiert ist
         if (!paralizeHandler.IsPlayerParalized(0))

--- a/src/WaterWizard.Server/handler/ParalizeHandler.cs
+++ b/src/WaterWizard.Server/handler/ParalizeHandler.cs
@@ -19,7 +19,7 @@ public class ParalizeHandler
 {
     private readonly GameState gameState;
 
-    // Paralize-Timer für jeden Spieler (in Millisekunden)
+    // Paralize-Timer für jeden Spieler (in Sekunden für Konsistenz)
     private float player1ParalizeTimer = 0f;
     private float player2ParalizeTimer = 0f;
 
@@ -43,13 +43,13 @@ public class ParalizeHandler
 
         if (playerIndex == 0)
         {
-            player1ParalizeTimer = durationSeconds * 1000f; // Konvertiere zu Millisekunden
+            player1ParalizeTimer = durationSeconds; // Direkt in Sekunden speichern
             Console.WriteLine($"[ParalizeHandler] Player 1 paralyzed for {durationSeconds} seconds");
             Console.WriteLine($"[ParalizeHandler] Player 1 Mana-Timer gestoppt - keine Mana-Generierung während Paralize");
         }
         else if (playerIndex == 1)
         {
-            player2ParalizeTimer = durationSeconds * 1000f; // Konvertiere zu Millisekunden
+            player2ParalizeTimer = durationSeconds; // Direkt in Sekunden speichern
             Console.WriteLine($"[ParalizeHandler] Player 2 paralyzed for {durationSeconds} seconds");
             Console.WriteLine($"[ParalizeHandler] Player 2 Mana-Timer gestoppt - keine Mana-Generierung während Paralize");
         }
@@ -62,14 +62,14 @@ public class ParalizeHandler
     /// <summary>
     /// Aktualisiert die Paralize-Timer basierend auf der verstrichenen Zeit
     /// </summary>
-    /// <param name="deltaTimeMs">Verstrichene Zeit in Millisekunden</param>
-    public void UpdateParalizeTimers(float deltaTimeMs)
+    /// <param name="deltaTimeSeconds">Verstrichene Zeit in Sekunden</param>
+    public void UpdateParalizeTimers(float deltaTimeSeconds)
     {
         bool statusChanged = false;
 
         if (player1ParalizeTimer > 0f)
         {
-            player1ParalizeTimer -= deltaTimeMs;
+            player1ParalizeTimer -= deltaTimeSeconds;
             if (player1ParalizeTimer <= 0f)
             {
                 player1ParalizeTimer = 0f;
@@ -81,7 +81,7 @@ public class ParalizeHandler
 
         if (player2ParalizeTimer > 0f)
         {
-            player2ParalizeTimer -= deltaTimeMs;
+            player2ParalizeTimer -= deltaTimeSeconds;
             if (player2ParalizeTimer <= 0f)
             {
                 player2ParalizeTimer = 0f;


### PR DESCRIPTION
This pull request refactors the `ManaHandler` and `ParalizeHandler` classes to improve time handling consistency by switching from milliseconds to seconds and ensuring accurate delta-time calculations. The most important changes include introducing a time-tracking mechanism in `ManaHandler`, updating the paralysis logic in `ParalizeHandler` to use seconds, and modifying method signatures and calculations accordingly.

### Improvements to time handling in `ManaHandler`:
* Added a `lastManaUpdate` field to track the last update time in `ManaHandler`, enabling accurate delta-time calculations. (`src/WaterWizard.Server/handler/ManaHandler.cs`, [src/WaterWizard.Server/handler/ManaHandler.csR22](diffhunk://#diff-9baf07d14afff2123c300be85c270eddf4cc790a1af87d6bed45030c215a5fa4R22))
* Updated the `UpdateMana` method to calculate delta time based on the actual elapsed time and pass this value to `UpdateParalizeTimers`, replacing the fixed 4000ms duration. (`src/WaterWizard.Server/handler/ManaHandler.cs`, [src/WaterWizard.Server/handler/ManaHandler.csL34-R41](diffhunk://#diff-9baf07d14afff2123c300be85c270eddf4cc790a1af87d6bed45030c215a5fa4L34-R41))

### Consistency improvements in `ParalizeHandler`:
* Changed the internal representation of paralysis timers from milliseconds to seconds for consistency. (`src/WaterWizard.Server/handler/ParalizeHandler.cs`, [src/WaterWizard.Server/handler/ParalizeHandler.csL22-R22](diffhunk://#diff-603375d08c5048911611bb39fb6c6bd01b7736013a0d9ba67165f1aa776790ecL22-R22))
* Updated the `ActivateParalize` method to store durations directly in seconds instead of converting from milliseconds. (`src/WaterWizard.Server/handler/ParalizeHandler.cs`, [src/WaterWizard.Server/handler/ParalizeHandler.csL46-R52](diffhunk://#diff-603375d08c5048911611bb39fb6c6bd01b7736013a0d9ba67165f1aa776790ecL46-R52))
* Modified the `UpdateParalizeTimers` method to accept elapsed time in seconds and adjusted the timer decrement logic accordingly. (`src/WaterWizard.Server/handler/ParalizeHandler.cs`, [[1]](diffhunk://#diff-603375d08c5048911611bb39fb6c6bd01b7736013a0d9ba67165f1aa776790ecL65-R72) [[2]](diffhunk://#diff-603375d08c5048911611bb39fb6c6bd01b7736013a0d9ba67165f1aa776790ecL84-R84)