### PR TITLE
B404 summon ship card fix

### DIFF
--- a/src/WaterWizard.Server/handler/UtilityCardHandler.cs
+++ b/src/WaterWizard.Server/handler/UtilityCardHandler.cs
@@ -11,6 +11,7 @@
 using System.Numerics;
 using LiteNetLib;
 using WaterWizard.Server;
+using WaterWizard.Server.Card.utility;
 using WaterWizard.Shared;
 
 namespace WaterWizard.Server.handler;
@@ -59,6 +60,10 @@ public class UtilityCardHandler
                 Console.WriteLine($"[UtilityCardHandler] ConeOfCold-Karte aktiviert!");
                 HandleConeOfCold(targetCoords, caster, defender);
                 break;
+            case CardVariant.SummonShip:
+                Console.WriteLine($"[UtilityCardHandler] SummonShip-Karte aktiviert!");
+                HandleSummonShip(targetCoords, caster, defender);
+                break;
             default:
                 Console.WriteLine($"[UtilityCardHandler] Unbekannte Utility-Karte: {variant}");
                 break;
@@ -82,7 +87,7 @@ public class UtilityCardHandler
         int shipId = (int)(targetCoords.X) >> 16;
         int destinationX = (int)targetCoords.X & 0xFFFF;
         int destinationY = (int)targetCoords.Y;
-        
+
         Console.WriteLine($"[UtilityCardHandler] Teleport ship {shipId} to ({destinationX}, {destinationY})");
     }
 
@@ -111,5 +116,18 @@ public class UtilityCardHandler
     {
         // TODO: Implementiere Verwandlungseffekt
         Console.WriteLine($"[UtilityCardHandler] Polymorph at ({targetCoords.X}, {targetCoords.Y})");
+    }
+    
+    /// <summary>
+    /// Handles the SummonShip card (summons a ship at the target coordinates)
+    /// </summary>
+    /// <param name="targetCoords">Target Coordinates where the ship will be summoned</param>
+    /// <param name="caster">The Player that uses the card</param>
+    /// <param name="defender">The Player that is affected by the card</param>
+    private void HandleSummonShip(Vector2 targetCoords, NetPeer caster, NetPeer defender)
+    {
+        var summonShipCard = new SummonShipCard();
+        summonShipCard.ExecuteUtility(gameState, targetCoords, caster, defender);
+        Console.WriteLine($"[UtilityCardHandler] SummonShip executed at ({targetCoords.X}, {targetCoords.Y})");
     }
 }


### PR DESCRIPTION
This pull request enhances the `UtilityCardHandler` in the `WaterWizard.Server` project by adding support for a new card type, `SummonShip`. The changes include importing the required class, extending the card handling logic, and implementing the functionality for the new card.

### New Card Support:

* **Added `SummonShip` card handling logic**:
  - Updated the `HandleUtilityCard` method to include a new case for `CardVariant.SummonShip` that logs activation and delegates processing to a dedicated method. (`[src/WaterWizard.Server/handler/UtilityCardHandler.csR63-R66](diffhunk://#diff-e91d6f7f96ebb76296d964f191eaef9b94240b00f6f224c1f37d8c48abf60771R63-R66)`)
  - Implemented the `HandleSummonShip` method to execute the `SummonShip` card's effect, which summons a ship at the specified coordinates. This includes logging the action and invoking the `ExecuteUtility` method of the `SummonShipCard` class. (`[src/WaterWizard.Server/handler/UtilityCardHandler.csR120-R132](diffhunk://#diff-e91d6f7f96ebb76296d964f191eaef9b94240b00f6f224c1f37d8c48abf60771R120-R132)`)

### Code Import:

* **Added required namespace import**:
  - Imported `WaterWizard.Server.Card.utility` to access the `SummonShipCard` class. (`[src/WaterWizard.Server/handler/UtilityCardHandler.csR14](diffhunk://#diff-e91d6f7f96ebb76296d964f191eaef9b94240b00f6f224c1f37d8c48abf60771R14)`)