### PR TITLE
Add card activation for damage, healing, utility, and environment cards

### DIFF
--- a/src/WaterWizard.Server/CardAbilities.cs
+++ b/src/WaterWizard.Server/CardAbilities.cs
@@ -61,6 +61,11 @@ public static class CardAbilities
                         {
                             gameState.CheckGameOver();
                         }
+                        
+                        // Add damage card to active cards list
+                        var card = new Cards(variant);
+                        int duration = card.Duration == "instant" ? 0 : (int.TryParse(card.Duration, out int d) ? d : 0);
+                        CardHandler.CardActivation(gameState, variant, duration);
                     }
                 }
                 else
@@ -97,6 +102,11 @@ public static class CardAbilities
                         {
                             gameState.CheckGameOver();
                         }
+                        
+                        // Add healing card to active cards list
+                        var card = new Cards(variant);
+                        int duration = card.Duration == "instant" ? 0 : (int.TryParse(card.Duration, out int d) ? d : 0);
+                        CardHandler.CardActivation(gameState, variant, duration);
                     }
                 }
                 else
@@ -132,6 +142,11 @@ public static class CardAbilities
                         {
                             gameState.CheckGameOver();
                         }
+                        
+                        // Add utility card to active cards list
+                        var card = new Cards(variant);
+                        int duration = card.Duration == "instant" ? 0 : (int.TryParse(card.Duration, out int d) ? d : 0);
+                        CardHandler.CardActivation(gameState, variant, duration);
                     }
                 }
                 else
@@ -166,6 +181,14 @@ public static class CardAbilities
                         if (environmentExecuted)
                         {
                             gameState.CheckGameOver();
+                        }
+                        
+                        // Add environment card to active cards list (but Thunder already handles this itself)
+                        if (variant != CardVariant.Thunder)
+                        {
+                            var card = new Cards(variant);
+                            int duration = card.Duration == "instant" ? 0 : (int.TryParse(card.Duration, out int d) ? d : 0);
+                            CardHandler.CardActivation(gameState, variant, duration);
                         }
                     }
                 }


### PR DESCRIPTION
This pull request adds functionality to handle different types of cards (`damage`, `healing`, `utility`, and `environment`) in the `NetPeer defender` class by activating them and adding them to the active cards list. It also includes a special case for the `Thunder` environment card. 

### Additions for card activation:

* [`src/WaterWizard.Server/CardAbilities.cs`](diffhunk://#diff-ccf71f8ab7d7a80af946f01b2de95b5b22ec2b0b767a5f6c4437ad05f7a0550cR64-R68): Added logic to activate `damage`, `healing`, and `utility` cards by creating a `Cards` object, determining the card's duration, and invoking `CardHandler.CardActivation`. [[1]](diffhunk://#diff-ccf71f8ab7d7a80af946f01b2de95b5b22ec2b0b767a5f6c4437ad05f7a0550cR64-R68) [[2]](diffhunk://#diff-ccf71f8ab7d7a80af946f01b2de95b5b22ec2b0b767a5f6c4437ad05f7a0550cR105-R109) [[3]](diffhunk://#diff-ccf71f8ab7d7a80af946f01b2de95b5b22ec2b0b767a5f6c4437ad05f7a0550cR145-R149)

* [`src/WaterWizard.Server/CardAbilities.cs`](diffhunk://#diff-ccf71f8ab7d7a80af946f01b2de95b5b22ec2b0b767a5f6c4437ad05f7a0550cR185-R192): Added logic to activate `environment` cards, excluding the `Thunder` variant, which handles its own activation.