### PR TITLE
B237 fix fullscreen

### DIFF
--- a/src/WaterWizard.Client/gamescreen/GameScreen.cs
+++ b/src/WaterWizard.Client/gamescreen/GameScreen.cs
@@ -482,6 +482,12 @@ public class GameScreen(
         var oldBoardPosition = playerBoard.Position;
         Initialize();
         UpdateShipPosition(oldBoardPosition, oldCellSize);
+        
+        // Reinitialize ShipField to fix draggable ship positions
+        if (shipField != null)
+        {
+            shipField.Initialize();
+        }
     }
 
     private static void UpdateShipPosition(Vector2 oldBoardPosition, int oldCellSize)

--- a/src/WaterWizard.Client/gamescreen/handler/HandleShips.cs
+++ b/src/WaterWizard.Client/gamescreen/handler/HandleShips.cs
@@ -364,10 +364,19 @@ public class HandleShips
         GameStateManager.Instance.GameScreen.playerBoard!.Ships.ForEach(ship =>
         {
             var board = GameStateManager.Instance.GameScreen.playerBoard!;
-            var prevX = (ship.X - oldBoardPosition.X) / oldCellSize;
-            var prevY = (ship.Y - oldBoardPosition.Y) / oldCellSize;
-            ship.X = (int)(board.Position.X + prevX) * board.CellSize;
-            ship.Y = (int)(board.Position.Y + prevY) * board.CellSize;
+
+            var gridX = (ship.X - oldBoardPosition.X) / oldCellSize;
+            var gridY = (ship.Y - oldBoardPosition.Y) / oldCellSize;
+            
+
+            ship.X = (int)(board.Position.X + gridX * board.CellSize);
+            ship.Y = (int)(board.Position.Y + gridY * board.CellSize);
+            
+
+            var gridWidth = ship.Width / (int)oldCellSize;
+            var gridHeight = ship.Height / (int)oldCellSize;
+            ship.Width = gridWidth * board.CellSize;
+            ship.Height = gridHeight * board.CellSize;
         });
     }
 }


### PR DESCRIPTION
This pull request addresses issues related to ship positioning and resizing in the game screen, ensuring proper alignment and scaling after screen size updates. The changes focus on reinitializing components and improving calculations for ship dimensions and positions.

### Changes to ship positioning and resizing:

* [`src/WaterWizard.Client/gamescreen/GameScreen.cs`](diffhunk://#diff-c38527117831c7c5228cc4fa600893a8d8815abf29c4a0836432211390ea31cbR485-R490): Added logic to reinitialize the `shipField` after updating the screen size to fix draggable ship positions. (`[src/WaterWizard.Client/gamescreen/GameScreen.csR485-R490](diffhunk://#diff-c38527117831c7c5228cc4fa600893a8d8815abf29c4a0836432211390ea31cbR485-R490)`)
* [`src/WaterWizard.Client/gamescreen/handler/HandleShips.cs`](diffhunk://#diff-4d2d681d9fed804a846ec72c886a5a7d614d8af0eb82fdf2f494c194ecdd027eL367-R379): Adjusted calculations for ship positions and dimensions during full-screen updates, ensuring proper scaling of `Width` and `Height` in addition to `X` and `Y` coordinates. (`[src/WaterWizard.Client/gamescreen/handler/HandleShips.csL367-R379](diffhunk://#diff-4d2d681d9fed804a846ec72c886a5a7d614d8af0eb82fdf2f494c194ecdd027eL367-R379)`)