### PR TITLE
B417 Fireball not working

### DIFF
--- a/src/WaterWizard.Server/Card/damage/FirballCard.cs
+++ b/src/WaterWizard.Server/Card/damage/FirballCard.cs
@@ -12,138 +12,143 @@ using WaterWizard.Server.handler;
 using WaterWizard.Server.Interface;
 using WaterWizard.Shared;
 
-namespace WaterWizard.Server.Card;
-
-/// <summary>
-/// Implementation of the Fireball damage card
-/// Deals damage to a 3x3 area centered on the target coordinate
-/// </summary>
-public class FireballCard : IDamageCard
+namespace WaterWizard.Server.Card.damage
 {
     /// <summary>
-    /// The variant of the card
+    /// Implementation of the Fireball damage card
+    /// Deals damage to a 3x3 area centered on the target coordinate
     /// </summary>
-    public CardVariant Variant => CardVariant.Fireball;
-
-    /// <summary>
-    /// The area of effect as a Vector2 (width x height)
-    /// </summary>
-    public Vector2 AreaOfEffect => new(3, 3);
-
-    /// <summary>
-    /// The base damage this card deals
-    /// </summary>
-    public int BaseDamage => 3;
-
-    /// <summary>
-    /// Whether this card has special targeting rules
-    /// </summary>
-    public bool HasSpecialTargeting => false;
-
-    /// <summary>
-    /// Executes the damage effect of the Firebolt card
-    /// </summary>
-    /// <param name="gameState">The current game state</param>
-    /// <param name="targetCoords">The coordinates targeted by the card</param>
-    /// <param name="attacker">The attacking player</param>
-    /// <param name="defender">The defending player</param>
-    public bool ExecuteDamage(
-        GameState gameState,
-        Vector2 targetCoords,
-        NetPeer attacker,
-        NetPeer defender
-    )
+    public class FireballCard : IDamageCard
     {
-        int startX = (int)targetCoords.X - 1;
-        int startY = (int)targetCoords.Y - 1;
+        /// <summary>
+        /// The variant of the card
+        /// </summary>
+        public CardVariant Variant => CardVariant.Fireball;
 
-        var ships = ShipHandler.GetShips(defender);
-        bool anyHit = false;
+        /// <summary>
+        /// The area of effect as a Vector2 (width x height)
+        /// </summary>
+        public Vector2 AreaOfEffect => new(3, 3);
 
-        for (int dx = 0; dx < (int)AreaOfEffect.X; dx++)
+        /// <summary>
+        /// The base damage this card deals
+        /// </summary>
+        public int BaseDamage => 3;
+
+        /// <summary>
+        /// Whether this card has special targeting rules
+        /// </summary>
+        public bool HasSpecialTargeting => false;
+
+        /// <summary>
+        /// Executes the damage effect of the Fireball card
+        /// </summary>
+        /// <param name="gameState">The current game state</param>
+        /// <param name="targetCoords">The coordinates targeted by the card</param>
+        /// <param name="attacker">The attacking player</param>
+        /// <param name="defender">The defending player</param>
+        public bool ExecuteDamage(
+            GameState gameState,
+            Vector2 targetCoords,
+            NetPeer attacker,
+            NetPeer defender
+        )
         {
-            for (int dy = 0; dy < (int)AreaOfEffect.Y; dy++)
+            int startX = (int)targetCoords.X - 1;
+            int startY = (int)targetCoords.Y - 1;
+
+            var ships = ShipHandler.GetShips(defender);
+            bool anyHit = false;
+
+            int defenderIndex = gameState.GetPlayerIndex(defender);
+
+            for (int dx = 0; dx < (int)AreaOfEffect.X; dx++)
             {
-                int x = startX + dx;
-                int y = startY + dy;
-                bool cellHit = false;
-
-                foreach (var ship in ships)
+                for (int dy = 0; dy < (int)AreaOfEffect.Y; dy++)
                 {
-                    if (
-                        x >= ship.X
-                        && x < ship.X + ship.Width
-                        && y >= ship.Y
-                        && y < ship.Y + ship.Height
-                    )
-                    {
-                        cellHit = true;
-                        bool newDamage = ship.DamageCell(x, y);
+                    int x = startX + dx;
+                    int y = startY + dy;
+                    bool cellHit = false;
 
-                        if (newDamage)
+                    if (defenderIndex != -1 && gameState.IsCoordinateProtectedByShield(x, y, defenderIndex))
+                    {
+                        Console.WriteLine($"[Server] Fireball attack at ({x}, {y}) blocked by shield!");
+                        CellHandler.SendCellReveal(attacker, defender, x, y, false, "Fireball");
+                        continue;
+                    }
+
+                    foreach (var ship in ships)
+                    {
+                        if (
+                            x >= ship.X
+                            && x < ship.X + ship.Width
+                            && y >= ship.Y
+                            && y < ship.Y + ship.Height
+                        )
                         {
-                            if (ship.IsDestroyed)
+                            cellHit = true;
+                            bool newDamage = ship.DamageCell(x, y);
+
+                            Console.WriteLine(
+                                $"[Server] Fireball hit ship at ({ship.X}, {ship.Y}), new damage: {newDamage}"
+                            );
+
+                            if (newDamage)
                             {
-                                CellHandler.SendCellReveal(
-                                    attacker,
-                                    defender,
-                                    x,
-                                    y,
-                                    true,
-                                    "FireBall"
-                                );
-                                gameState.CheckGameOver();
+                                if (ship.IsDestroyed)
+                                {
+                                    Console.WriteLine(
+                                        $"[Server] Fireball destroyed ship at ({ship.X}, {ship.Y})!"
+                                    );
+                                    CellHandler.SendCellReveal(attacker, defender, x, y, true, "Fireball");
+                                    ShipHandler.SendShipReveal(attacker, ship, gameState);
+                                    gameState.CheckGameOver();
+                                }
+                                else
+                                {
+                                    CellHandler.SendCellReveal(attacker, defender, x, y, true, "Fireball");
+                                }
                             }
                             else
                             {
-                                CellHandler.SendCellReveal(
-                                    attacker,
-                                    defender,
-                                    x,
-                                    y,
-                                    true,
-                                    "FireBall"
-                                );
+                                CellHandler.SendCellReveal(attacker, defender, x, y, true, "Fireball");
                             }
+                            break;
                         }
-                        else
-                        {
-                            CellHandler.SendCellReveal(attacker, defender, x, y, true, "FireBall");
-                        }
-                        break;
+                    }
+
+                    if (!cellHit)
+                    {
+                        Console.WriteLine($"[Server] Fireball missed at ({x}, {y})");
+                        CellHandler.SendCellReveal(attacker, defender, x, y, false, "Fireball");
+                    }
+
+                    if (cellHit)
+                    {
+                        anyHit = true;
                     }
                 }
-
-                if (!cellHit)
-                {
-                    CellHandler.SendCellReveal(attacker, defender, x, y, false, "FireBall");
-                }
-
-                if (cellHit)
-                {
-                    anyHit = true;
-                }
             }
+
+            return anyHit;
         }
 
-        return anyHit;
-    }
+        /// <summary>
+        /// Validates if the target coordinates are valid for this card
+        /// </summary>
+        /// <param name="gameState">The current game state.</param>
+        /// <param name="targetCoords">The coordinates targeted by the card.</param>
+        /// <param name="defender">The defending player.</param>
+        /// <returns>True if the target area is within the board, otherwise false.</returns>
+        public bool IsValidTarget(GameState gameState, Vector2 targetCoords, NetPeer defender)
+        {
+            int boardWidth = 12;
+            int boardHeight = 10;
 
-    /// <summary>
-    /// Validates if the target coordinates are valid for this card
-    /// </summary>
-    /// <param name="gameState">The current game state.</param>
-    /// <param name="targetCoords">The coordinates targeted by the card.</param>
-    /// <param name="defender">The defending player.</param>
-    /// <returns>True if the target area is within the board, otherwise false.</returns>
-    public bool IsValidTarget(GameState gameState, Vector2 targetCoords, NetPeer defender)
-    {
-        int boardWidth = 12;
-        int boardHeight = 10;
-
-        return targetCoords.X >= 1
-            && targetCoords.Y >= 1
-            && targetCoords.X + 2 < boardWidth
-            && targetCoords.Y + 2 < boardHeight;
+            return targetCoords.X >= 1
+                && targetCoords.Y >= 1
+                && targetCoords.X + 2 < boardWidth
+                && targetCoords.Y + 2 < boardHeight;
+        }
     }
 }


### PR DESCRIPTION
This pull request refactors and enhances the `FireballCard` damage effect in the WaterWizard server. The main improvements include better namespace organization, more robust shield protection logic, improved logging for attacks, and consistent naming for the "Fireball" effect. These changes make the code easier to maintain and debug, and ensure that shielded cells are properly handled during area-of-effect attacks.

**Code organization:**

* Moved `FireballCard` implementation to the `WaterWizard.Server.Card.damage` namespace for better code organization.

**Gameplay logic improvements:**

* Added logic to check if a cell is protected by a shield before applying damage, and skip damage if shielded. This prevents the Fireball effect from damaging shielded cells. [[1]](diffhunk://#diff-a82c3d9eb16ad15799fe8209967f205f30c2f70c21f1a2676b99f205cd79f8d8R63-R64) [[2]](diffhunk://#diff-a82c3d9eb16ad15799fe8209967f205f30c2f70c21f1a2676b99f205cd79f8d8R73-R79)

**Logging and debugging enhancements:**

* Added detailed logging for Fireball attacks, including when attacks are blocked by shields, when ships are hit or destroyed, and when attacks miss, making server-side debugging easier. [[1]](diffhunk://#diff-a82c3d9eb16ad15799fe8209967f205f30c2f70c21f1a2676b99f205cd79f8d8R73-R79) [[2]](diffhunk://#diff-a82c3d9eb16ad15799fe8209967f205f30c2f70c21f1a2676b99f205cd79f8d8R92-R123)

**Consistency and naming fixes:**

* Standardized the effect name to "Fireball" in all calls to `CellHandler.SendCellReveal` for consistency (previously "FireBall" was used in some places). [[1]](diffhunk://#diff-a82c3d9eb16ad15799fe8209967f205f30c2f70c21f1a2676b99f205cd79f8d8R92-R123) [[2]](diffhunk://#diff-a82c3d9eb16ad15799fe8209967f205f30c2f70c21f1a2676b99f205cd79f8d8L44-R44)

**Miscellaneous:**

* Added missing closing brace to properly terminate the class and namespace.